### PR TITLE
Relax python version requirement to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --hook-stage manual --all-files
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"] # TODO: Change 3.11 to a lower version when resolving #6
+        python-version: ["3.9", "3.12"]
         runs-on: [ubuntu-latest, windows-latest]
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.9"
 sphinx:
   configuration: docs/conf.py
 

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Installation
 Requirements
 ~~~~~~~~~~~~
 
-Python 3.11 on Windows or Linux.
+Python 3.9 or later on Windows or Linux.
 
 Create Virtual Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ def lint(session: nox.Session) -> None:
     )
 
 
-@nox.session(python='3.11')
+@nox.session()
 def pylint(session: nox.Session) -> None:
     """
     Run PyLint.
@@ -35,7 +35,7 @@ def pylint(session: nox.Session) -> None:
     session.run("pylint", "openlifu", *session.posargs)
 
 
-@nox.session(python='3.11')
+@nox.session()
 def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ ignore = [
   "T201", # `print` found
   "SIM102", # Use a single `if` statement instead of nested `if` statements
   "SIM118", # Use `key not in dict` instead of `key not in dict.keys()`
-  "PLR1701", # Merge `isinstance` calls: `isinstance(d, (list, tuple))`
   "SIM101", # Multiple `isinstance` calls for `d`, merge into a single call
   "RET503", # Missing explicit `return` at the end of function able to return non-`None` value
   "B006", # Do not use mutable data structures for argument defaults

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "Openwater Focused Ultrasound Toolkit"
 readme = "README.rst"
 license.file = "LICENSE"
-requires-python = ">=3.11" # TODO: Decrease this version number when resolving #6
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 1 - Planning",
   "Intended Audience :: Science/Research",
@@ -21,9 +21,8 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-#  "Programming Language :: Python :: 3.8", # TODO: Uncomment some of these when resolving #6
-#  "Programming Language :: Python :: 3.9",
-#  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering",

--- a/src/openlifu/seg/material.py
+++ b/src/openlifu/seg/material.py
@@ -42,7 +42,7 @@ class Material:
     @staticmethod
     def get_materials(material_id="all", as_dict=True):
         material_id = ("water", "tissue", "skull", "air", "standoff") if material_id == "all" else material_id
-        if isinstance(material_id, tuple) or  isinstance(material_id, list):
+        if isinstance(material_id, (list, tuple)):
             materials = {m: Material.get_materials(m, as_dict=False) for m in material_id}
         elif material_id in MATERIALS:
             materials = MATERIALS[material_id]
@@ -55,7 +55,7 @@ class Material:
 
     @staticmethod
     def from_dict(d):
-        if isinstance(d, list) or isinstance(d, tuple):
+        if isinstance(d, (list, tuple)):
             return {dd['id']: Material.from_dict(dd) for dd in d}
         elif isinstance(d, str):
             return Material.get_materials(d, as_dict=False)


### PR DESCRIPTION
Closes #6

I tried out the notebook `test_first.ipynb` (including the fixes from #21) with a python3.9 environment and the notebook ran without issues.

@peterhollender Is there anything else I should test besides that the notebook `test_first` runs to ensure that things work with Python 3.9? Any other reason for previously requiring 3.11 that I could be forgetting?