### PR TITLE
Make k-wave-python a direct dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.12"]
-        runs-on: [ubuntu-latest, windows-latest]
+        runs-on: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,8 @@ dependencies = [
   "nibabel",
   "sphinx",
   "ipykernel",
-  "k-wave-python @ git+https://github.com/waltsims/k-wave-python"
+  "k-wave-python>=0.3.4",
 ]
-
-# We should remove this section once we resolve the k-wave-python issue
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Closes #7

It was previously indirect becasue of a windows issue in the main codebase that had yet to be released.

The new release is said to support MacOS so we open that up for testing in the CI.