### PR TITLE
Fix gitignore of ipynb files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
-*.ipynb # We use jupytext to avoid mixing notebooks into version control.
+*.ipynb
 
 # IPython
 profile_default/


### PR DESCRIPTION
This is a fixup of 0efbc2c907b00e9eb2b7265204a9373d5aefaeef for Issue #15. Apparently the inline comment prevented it from actually ignoring .ipynb files.

Thanks @peterhollender for catching that