### PR TITLE
Support serialization for Protocols and Transducers (#85)

### DIFF
--- a/src/openlifu/bf/__init__.py
+++ b/src/openlifu/bf/__init__.py
@@ -1,5 +1,5 @@
 from .delay_methods import DelayMethod
 from .apod_methods import ApodizationMethod
-from .focal_patterns import FocalPattern
+from .focal_patterns import FocalPattern, SinglePoint, Wheel
 from .pulse import Pulse
 from .sequence import Sequence

--- a/src/openlifu/plan/protocol.py
+++ b/src/openlifu/plan/protocol.py
@@ -11,7 +11,7 @@ class Protocol:
     description: str = ""
     pulse: bf.Pulse = field(default_factory=bf.Pulse)
     sequence: bf.Sequence = field(default_factory=bf.Sequence)
-    focal_pattern: bf.FocalPattern = field(default_factory=bf.FocalPattern)
+    focal_pattern: bf.FocalPattern = field(default_factory=bf.SinglePoint)
     sim_setup: sim.SimSetup = field(default_factory=sim.SimSetup)
     delay_method: bf.DelayMethod = field(default_factory=bf.delay_methods.Direct)
     apod_method: bf.ApodizationMethod = field(default_factory=bf.apod_methods.Uniform)

--- a/src/openlifu/xdc/transducer.py
+++ b/src/openlifu/xdc/transducer.py
@@ -199,6 +199,24 @@ class Transducer:
         return Transducer(**d, **kwargs)
 
     @staticmethod
+    def from_json(json_string : str) -> "Transducer":
+        """Load a Transducer from a json string"""
+        return Transducer.from_dict(json.loads(json_string))
+
+    def to_json(self, compact:bool) -> str:
+        """Serialize a Transducer to a json string
+
+        Args:
+            compact: if enabled then the string is compact (not pretty). Disable for pretty.
+
+        Returns: A json string representing the complete Transducer object.
+        """
+        if compact:
+            return json.dumps(self.to_dict(), separators=(',', ':'))
+        else:
+            return json.dumps(self.to_dict(), indent=4)
+
+    @staticmethod
     def gen_matrix_array(nx=2, ny=2, pitch=1, kerf=0, units="mm", impulse_response=1, impulse_dt=1, id='array', name='Array', attrs={}):
         N = nx * ny
         xpos = [(i - nx // 2) * pitch for i in range(nx)]

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,11 @@
+from openlifu import Protocol
+from pathlib import Path
+import pytest
+
+@pytest.fixture()
+def example_protocol() -> Protocol:
+    return Protocol.from_file(Path(__file__).parent/'resources/example_db/protocols/example_protocol/example_protocol.json')
+
+@pytest.mark.parametrize("compact_representation", [True, False])
+def test_serialize_deserialize_protocol(example_protocol : Protocol, compact_representation: bool):
+    assert example_protocol.from_json(example_protocol.to_json(compact_representation)) == example_protocol

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -9,3 +9,7 @@ def example_protocol() -> Protocol:
 @pytest.mark.parametrize("compact_representation", [True, False])
 def test_serialize_deserialize_protocol(example_protocol : Protocol, compact_representation: bool):
     assert example_protocol.from_json(example_protocol.to_json(compact_representation)) == example_protocol
+
+def test_default_protocol():
+    """Ensure it is possible to construct a default protocol"""
+    Protocol()

--- a/tests/test_seg_method.py
+++ b/tests/test_seg_method.py
@@ -1,0 +1,36 @@
+from openlifu.seg import SegmentationMethod, Material
+from pathlib import Path
+import pytest
+
+@pytest.fixture()
+def example_seg_method() -> SegmentationMethod:
+    return SegmentationMethod(
+        materials = {
+            'water' : Material(
+                id="water",
+                name="water",
+                sound_speed=1500.0,
+                density=1000.0,
+                attenuation=0.0,
+                specific_heat=4182.0,
+                thermal_conductivity=0.598
+            ),
+            'skull' : Material(
+                id="skull",
+                name="skull",
+                sound_speed=4080.0,
+                density=1900.0,
+                attenuation=0.0,
+                specific_heat=1100.0,
+                thermal_conductivity=0.3
+            ),
+        },
+        ref_material = 'water',
+    )
+
+def test_seg_method_dict_conversion(example_seg_method : SegmentationMethod):
+    assert SegmentationMethod.from_dict(example_seg_method.to_dict()) == example_seg_method
+
+def test_seg_method_dict_conversion_with_varied_param_ids(example_seg_method : SegmentationMethod):
+    example_seg_method.materials['water'].param_ids = ("something", "else") # change param ids to something else
+    assert SegmentationMethod.from_dict(example_seg_method.to_dict()) == example_seg_method # verify that the dict conversion still works.

--- a/tests/test_transducer.py
+++ b/tests/test_transducer.py
@@ -1,0 +1,20 @@
+from openlifu import Transducer
+from pathlib import Path
+from dataclasses import fields
+import numpy as np
+import pytest
+
+@pytest.fixture()
+def example_transducer() -> Transducer:
+    return Transducer.from_file(Path(__file__).parent/'resources/example_db/transducers/example_transducer/example_transducer.json')
+
+@pytest.mark.parametrize("compact_representation", [True, False])
+def test_serialize_deserialize_transducer(example_transducer : Transducer, compact_representation: bool):
+    reconstructed_transducer = example_transducer.from_json(example_transducer.to_json(compact_representation))
+    for field in fields(example_transducer):
+        value_original = getattr(example_transducer, field.name)
+        value_reconstructed = getattr(reconstructed_transducer, field.name)
+        if isinstance(value_original, np.ndarray):
+            assert (value_original == value_reconstructed).all()
+        else:
+            assert value_original == value_reconstructed

--- a/tests/test_transducer.py
+++ b/tests/test_transducer.py
@@ -18,3 +18,7 @@ def test_serialize_deserialize_transducer(example_transducer : Transducer, compa
             assert (value_original == value_reconstructed).all()
         else:
             assert value_original == value_reconstructed
+
+def test_default_transducer():
+    """Ensure it is possible to construct a default transducer"""
+    Transducer()


### PR DESCRIPTION
Close #85 

- Make `Protocol.from_dict` work; it was previously broken due to the `sim_setup` step
- Add `from_json` and `to_json` methods to `Protocol`, and a unit test that ensures they go back and forth consistently
- Getting this to pass required some fixes to `SegmentationMethod` dict conversion:
  - Slightly narrowed the set of fields grabbed by `SegmentationMethod.to_dict`
  - Ensured that `SegmentationMethod.from_dict` knows how to construct `Material` objects when it needs to
- Add `from_json` and `to_json` methods to `Transducer`, and a unit test that ensures they go back and forth consistently
- Make sure it is possible to create a default protocol; it was not possible because it was trying to internally instantiate an abstract focal pattern

I see there is a custom `JSONEncoder` in `openlifu.util.json`, and I considered adding functionality there or re-using that in some way. But I opted not to because there isn't an openlifu-wide consistent method of serializing and deserializing to files; we are currently a bit all over the place with some classes doing their own thing and other classes using `openlifu.util.json`. So for now I'd rather just have `Protocol` and `Transducer` define their own personal serialization functions so that we can use them in SlicerOpenLIFU, and then later if there is interest we can revamp the serialization functionality across all of openlifu to be a bit more streamlined and consistent.