### PR TITLE
Add fix to create sessions directory if it doesn't exist

### DIFF
--- a/src/openlifu/db/database.py
+++ b/src/openlifu/db/database.py
@@ -316,7 +316,7 @@ class Database:
             self.logger.info("Session IDs for subject %s: %s", subject_id, session_ids)
             return session_ids
         else:
-            self.logger.warning("Sessions file not found for subject %s.", subject_id)
+            self.logger.info("Sessions file not found for subject %s.", subject_id)
             return []
 
     def get_volume_ids(self, subject_id):
@@ -595,6 +595,8 @@ class Database:
     def write_session_ids(self, subject_id, session_ids):
         session_data = {'session_ids': session_ids}
         sessions_filename = self.get_sessions_filename(subject_id)
+        if not os.path.isfile(sessions_filename):
+            self.logger.info(f"Added sessions.json file with session_id {session_ids} for subject {subject_id} to the database.")
         with open(sessions_filename, 'w') as f:
             json.dump(session_data, f)
 

--- a/src/openlifu/db/database.py
+++ b/src/openlifu/db/database.py
@@ -135,6 +135,9 @@ class Database:
         subject_filename = self.get_subject_filename(subject_id)
         subject.to_file(subject_filename)
 
+        # Create empty sessions.json file for subject
+        self.write_session_ids(subject_id, session_ids=[])
+
         if subject_id not in subject_ids:
             subject_ids.append(subject_id)
             self.write_subject_ids(subject_ids)
@@ -595,8 +598,9 @@ class Database:
     def write_session_ids(self, subject_id, session_ids):
         session_data = {'session_ids': session_ids}
         sessions_filename = self.get_sessions_filename(subject_id)
+        Path(sessions_filename).parent.mkdir(exist_ok=True) #sessions directory
         if not os.path.isfile(sessions_filename):
-            self.logger.info(f"Added sessions.json file with session_id {session_ids} for subject {subject_id} to the database.")
+            self.logger.info(f"Added sessions.json file for subject {subject_id} to the database.")
         with open(sessions_filename, 'w') as f:
             json.dump(session_data, f)
 

--- a/src/openlifu/db/session.py
+++ b/src/openlifu/db/session.py
@@ -177,6 +177,7 @@ class Session:
 
         :param filename: Name of the file
         """
+        Path(filename).parent.parent.mkdir(exist_ok=True) #sessions directory
         Path(filename).parent.mkdir(exist_ok=True)
         with open(filename, 'w') as file:
             file.write(self.to_json(compact=False))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -56,6 +56,14 @@ def test_write_subject(example_database : Database):
     reloaded_subject = example_database.load_subject("bleh")
     assert subject == reloaded_subject
 
+    # Empty sessions file is created
+    sessions_filename = example_database.get_sessions_filename(subject.id)
+    assert sessions_filename.exists()
+    assert sessions_filename.is_file()
+    assert sessions_filename.name == "sessions.json"
+    session_ids = example_database.get_session_ids(subject.id)
+    assert session_ids == []
+
     # Error raised when the subject already exists
     with pytest.raises(ValueError, match="already exists"):
         example_database.write_subject(subject, on_conflict=OnConflictOpts.ERROR)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -95,6 +95,14 @@ def test_write_session(example_database: Database, example_subject: Subject):
     reloaded_session = example_database.load_session(example_subject, session.id)
     assert reloaded_session.name == "new_name"
 
+    # When writing to a new subject
+    new_subject = Subject(id="bleh_new",name="Deb Jectson")
+    example_database.write_subject(new_subject, on_conflict=OnConflictOpts.OVERWRITE)
+    session = Session(name="bleh", id='a_session',subject_id=new_subject.id)
+    example_database.write_session(new_subject, session)
+    reloaded_session = example_database.load_session(new_subject, session.id)
+    assert reloaded_session.name == "bleh"
+
 def test_write_session_mismatched_id(example_database: Database, example_subject: Subject):
     session = Session(id='a_session',subject_id='bogus_id') # The subject ID here is different from the ID in example_subject
     with pytest.raises(ValueError, match="IDs do not match"):


### PR DESCRIPTION
Closes #137 
Closes #124 

This PR is similar to the one made for writing volumes when a new subject directory is created. 