### PR TITLE
Add skin surface computation tools (#149)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
   "ISC001",   # Conflicts with formatter
+  "PLC3002",  # Unnecessary inline lambda (in fact using an inline lambda can improve readability)
 
   # Exceptions below are specific to this project.
   # They may be relaxed later in future code improvements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ dependencies = [
   "ipykernel",
   "k-wave-python==0.3.4",
   "nvidia-ml-py",
-  "OpenEXR"
+  "OpenEXR",
+  "scikit-image",
 ]
 
 [project.optional-dependencies]

--- a/src/openlifu/seg/skinseg.py
+++ b/src/openlifu/seg/skinseg.py
@@ -1,13 +1,13 @@
 import numpy as np
+import skimage.filters
+import skimage.measure
 from scipy.ndimage import distance_transform_edt
-from skimage.filters import threshold_otsu
-from skimage.measure import label, regionprops
 
 
 def take_largest_connected_component(mask: np.ndarray) -> np.ndarray:
     """Given a boolean image array (or any integer numpy array), return a mask of the largest connected component."""
-    mask_labeled = label(mask)
-    connected_component_info = regionprops(mask_labeled)
+    mask_labeled = skimage.measure.label(mask)
+    connected_component_info = skimage.measure.regionprops(mask_labeled)
     largest_connected_componet_label = connected_component_info[np.argmax([rp.area for rp in connected_component_info])].label
     return (mask_labeled == largest_connected_componet_label)
 
@@ -47,7 +47,7 @@ def compute_foreground_mask(
         vol_array,
         [lower_quantile_for_otsu_threshold,upper_quantile_for_otsu_threshold]
     )
-    threshold_foreground = threshold_otsu(
+    threshold_foreground = skimage.filters.threshold_otsu(
         vol_array[(vol_array >= threshold_lower) & (vol_array <= threshold_upper)]
     )
     foreground_mask = vol_array >= threshold_foreground

--- a/src/openlifu/seg/skinseg.py
+++ b/src/openlifu/seg/skinseg.py
@@ -1,0 +1,82 @@
+import numpy as np
+from scipy.ndimage import distance_transform_edt
+from skimage.filters import threshold_otsu
+from skimage.measure import label, regionprops
+
+
+def take_largest_connected_component(mask: np.ndarray) -> np.ndarray:
+    """Given a boolean image array (or any integer numpy array), return a mask of the largest connected component."""
+    mask_labeled = label(mask)
+    connected_component_info = regionprops(mask_labeled)
+    largest_connected_componet_label = connected_component_info[np.argmax([rp.area for rp in connected_component_info])].label
+    return (mask_labeled == largest_connected_componet_label)
+
+def compute_foreground_mask(
+        vol_array : np.ndarray,
+        closing_radius : float = 9.,
+        lower_quantile_for_otsu_threshold : float = 0.02,
+        upper_quantile_for_otsu_threshold : float = 0.99,
+    ) -> np.ndarray:
+    """Given a 3D image array, return a boolean mask representing the "foreground."
+
+    Args:
+        vol_array: a 3D image array of shape (H,W,D)
+        closing_readius: the radius of the ball used in the morphological closing operation
+        lower_quantile_for_otsu_threshold: a number from 0 to 1. Before otsu thresholding,
+            values below this quantile are omitted from the histogram as outliers.
+        upper_quantile_for_otsu_threshold: a number from 0 to 1.  Before otsu thresholding,
+            values above this quantile are omitted from the histogram as outliers.
+
+    Returns: a boolean array of shape (H,W,D) representing a foreground mask
+
+    This is essentially a port of the BRAINSTools automated foreground masking algorithm.
+    - Original algorithm documentation: https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsroiauto.html
+    - Original algorithm code: https://github.com/BRAINSia/BRAINSTools/tree/7c37d9e8c238f66f8a83f997d9c9bb659c494c90/BRAINSROIAuto
+
+    The algorithm roughly works as follows:
+    - step 1: otsu thresholding
+    - step 2: keep only the largest connected component
+    - step 3: morphological closing
+    - step 4: hole filling
+
+    The default values of the parameters have been observed to work well for mm-spaced brain MRIs.
+    """
+
+    # step 1: otsu-threshold the image to create an initial foreground mask.
+    threshold_lower, threshold_upper = np.quantile(
+        vol_array,
+        [lower_quantile_for_otsu_threshold,upper_quantile_for_otsu_threshold]
+    )
+    threshold_foreground = threshold_otsu(
+        vol_array[(vol_array >= threshold_lower) & (vol_array <= threshold_upper)]
+    )
+    foreground_mask = vol_array >= threshold_foreground
+
+    # step 2: keep only the largest connected component to throw out spurious bits.
+    foreground_mask = take_largest_connected_component(foreground_mask)
+
+    # step 3: do a morphological closing.
+    # while this does fill some holes, that's not the main point since step 4 already fills holes.
+    # the point of this step is rather to clean up and smooth out the skin surface of small cavities.
+    pad_width = int(closing_radius+2) # pad to avoid the situation where dilation hits the boundary
+    foreground_mask_padded = np.pad(foreground_mask, pad_width, mode='constant')
+    background_edt = distance_transform_edt(~foreground_mask_padded)
+    foreground_dilated = background_edt <= closing_radius
+    foreground_dilated_edt = distance_transform_edt(foreground_dilated)
+    foreground_closed = foreground_dilated_edt >= closing_radius
+
+    # crop to undo the padding above
+    h,w,d = foreground_mask.shape
+    p = pad_width
+    foreground_mask = foreground_closed[p:p+h,p:p+w,p:p+d]
+
+    # step 4: take the complement of the largest connected component of the current background.
+    # the background mask at this point contains the "actual background" and possibly also some
+    # holes that are inside the foreground region. the largest connected component of this background
+    # mask is considered to be the "actual background."" this step therefore serves to fill
+    # any remaining holes in the foreground mask.
+    # this step is analogous to the seeded flood fill in the original algorithm:
+    # https://github.com/BRAINSia/BRAINSTools/blob/7c37d9e8c238f66f8a83f997d9c9bb659c494c90/BRAINSCommonLib/itkLargestForegroundFilledMaskImageFilter.hxx#L255-L302
+    foreground_mask = ~take_largest_connected_component(~foreground_mask)
+
+    return foreground_mask

--- a/tests/test_skinseg.py
+++ b/tests/test_skinseg.py
@@ -1,0 +1,47 @@
+from typing import Tuple
+
+import numpy as np
+
+from openlifu.seg.skinseg import (
+    compute_foreground_mask,
+    take_largest_connected_component,
+)
+
+
+def add_ball(
+    volume:np.ndarray,
+    center:Tuple[float,float,float],
+    radius:float,
+    value:float = 1.
+):
+    """Add a ball to a given 3D volume. Useful for creating test volumes."""
+    z_size, y_size, x_size = volume.shape
+
+    z, y, x = np.ogrid[:z_size, :y_size, :x_size]
+
+    dist_sq = (
+        (z - center[0])**2 +
+        (y - center[1])**2 +
+        (x - center[2])**2
+    )
+
+    volume[dist_sq <= radius**2] = value
+
+def test_take_largest_connected_component():
+    vol_array = np.zeros((20,20,20))
+    add_ball(vol_array, (5,5,5), 4) # ball of radius 4 at (5,5,5)
+    expected_output = np.copy(vol_array).astype(bool) # at the end we expect to only get this first ball
+    add_ball(vol_array, (15,15,15), 2) # smaller ball over at (15,15,15)
+    assert np.all(
+        take_largest_connected_component(vol_array) == expected_output
+    )
+
+def test_compute_foreground_mask():
+    vol_array = np.zeros((20,20,20))
+    add_ball(vol_array, (6,6,6), 5)
+    expected_output = np.copy(vol_array).astype(bool) # this first ball shall be the expected output
+    add_ball(vol_array, (6,5,5), 2, value=0.) # erase a hole inside this first ball
+    add_ball(vol_array, (15,15,15), 3) # make a smaller disconnected ball elsewhere
+    assert np.all(
+        compute_foreground_mask(vol_array) == expected_output
+    )

--- a/tests/test_skinseg.py
+++ b/tests/test_skinseg.py
@@ -2,11 +2,16 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+import vtk
 from scipy.linalg import expm
+from scipy.stats import skew
 
 from openlifu.seg.skinseg import (
+    cartesian_to_spherical,
     compute_foreground_mask,
     create_closed_surface_from_labelmap,
+    spherical_interpolator_from_mesh,
+    spherical_to_cartesian,
     take_largest_connected_component,
     vtk_img_from_array_and_affine,
 )
@@ -81,3 +86,116 @@ def test_create_closed_surface_from_labelmap():
         point_position = np.array(points.GetPoint(i))
         point_distance_from_sphere_center = np.linalg.norm(point_position - sphere_center, ord=2)
         assert np.abs(point_distance_from_sphere_center - sphere_radius) < 1.
+
+def test_spherical_coordinate_range():
+    """Verify that spherical coordinate output is in the prescribed value ranges"""
+    rng = np.random.default_rng(848)
+    # try all 8 octants of 3D space
+    for sign_x in [-1,1]:
+        for sign_y in [-1,1]:
+            for sign_z in [-1,1]:
+                cartesian_coords = np.array([sign_x, sign_y, sign_z]) * rng.random(size=3)
+                r, th, ph = cartesian_to_spherical(*cartesian_coords)
+                assert r>=0
+                assert 0 <= th <= np.pi
+                assert -np.pi <= ph <= np.pi
+
+def test_spherical_coordinate_conversion_inverse():
+    """Verify that the spherical coordinate conversion forward and backward functions are inverses of one another"""
+    rng = np.random.default_rng(241)
+    # try all 8 octants of 3D space
+    for sign_x in [-1,1]:
+        for sign_y in [-1,1]:
+            for sign_z in [-1,1]:
+                cartesian_coords = np.array([sign_x, sign_y, sign_z]) * rng.random(size=3)
+                np.testing.assert_almost_equal(
+                    spherical_to_cartesian(*cartesian_to_spherical(*cartesian_coords)),
+                    cartesian_coords
+                )
+                np.testing.assert_almost_equal(
+                    cartesian_to_spherical(*spherical_to_cartesian(*cartesian_to_spherical(*cartesian_coords))),
+                    cartesian_to_spherical(*cartesian_coords)
+                )
+
+def test_spherical_interpolator_from_mesh():
+    """Check using a torus that the spherical interpolator behaves reasonably"""
+    parametric_torus = vtk.vtkParametricTorus()
+    parametric_torus.SetRingRadius(12.)
+    parametric_torus.SetCrossSectionRadius(5)
+    parametric_function_source = vtk.vtkParametricFunctionSource()
+    parametric_function_source.SetUResolution(50)
+    parametric_function_source.SetVResolution(50)
+    parametric_function_source.SetParametricFunction(parametric_torus)
+    parametric_function_source.Update()
+    torus_polydata = parametric_function_source.GetOutput()
+
+    origin = (12., 0., 0.) # center at a point inside the torus, on the central ring of the torus
+    rng = np.random.default_rng(241)
+    xyz_direction_columns = expm((lambda A: (A - A.T)/2)(rng.normal(size=(3,3)))) # generate a random orthogonal matrix
+
+    interpolator = spherical_interpolator_from_mesh(
+        surface_mesh = torus_polydata,
+        origin = origin,
+        xyz_direction_columns = xyz_direction_columns,
+    )
+
+    sphere_source = vtk.vtkSphereSource()
+    sphere_source.SetRadius(1.0)
+    sphere_source.SetThetaResolution(50)  # Set the resolution in the theta direction
+    sphere_source.SetPhiResolution(50)  # Set the resolution in the phi direction
+    sphere_source.Update()
+    sphere_polydata = sphere_source.GetOutput()
+    sphere_points = sphere_polydata.GetPoints()
+    for i in range(sphere_points.GetNumberOfPoints()):
+        point = np.array(sphere_points.GetPoint(i))
+        r, theta, phi = cartesian_to_spherical(*point)
+        r = interpolator(theta, phi)
+        sphere_points.SetPoint(i, r * point)
+
+    xyz_affine = np.eye(4)
+    xyz_affine[:3,:3] = xyz_direction_columns
+    xyz_affine[:3,3] = origin
+    xyz_affine_vtkmat = vtk.vtkMatrix4x4()
+    xyz_affine_vtkmat.DeepCopy(xyz_affine.ravel())
+    xyz_transform = vtk.vtkTransform()
+    xyz_transform.SetMatrix(xyz_affine_vtkmat)
+    transform_filter = vtk.vtkTransformPolyDataFilter()
+    transform_filter.SetTransform(xyz_transform)
+    transform_filter.SetInputData(sphere_polydata)
+    transform_filter.Update()
+    sphere_polydata_transformed = transform_filter.GetOutput()
+
+    # These tools will be used to measure the disance between a point and a mesh
+    distance_from_torus = vtk.vtkImplicitPolyDataDistance()
+    distance_from_torus.SetInput(torus_polydata)
+    distance_from_sphere = vtk.vtkImplicitPolyDataDistance()
+    distance_from_sphere.SetInput(sphere_polydata_transformed)
+
+    # Now here is the unit test: sphere_polydata_transformed should be a sphere that has been "wrapped" around the torus.
+    # To test this we first check that (a) the points on sphere_polydata_transformed are generally close to the torus.
+    # Then we check that (b) the points of the torus are generally inside the sphere_polydata_transformed surface.
+    # We say "generally" and allow for a tolerance, because
+    # (a) some points on sphere_polydata_transformed will be far from the torus, for example as the sphere stretches over the donut hole
+    # (b) some points on the torus will slightly stick out of the sphere just because of the interpolation
+    # (the torus would be perfectly inside the sphere if the sphere mesh had infinite resolution, but it doesn't)
+    # This is why some tolerance is allowed in both checks.
+
+    sphere_transformed_points = sphere_polydata_transformed.GetPoints()
+    distances = [
+        np.abs(distance_from_torus.FunctionValue(sphere_transformed_points.GetPoint(i)))
+        for i in range(sphere_transformed_points.GetNumberOfPoints())
+    ]
+    assert np.quantile(distances,0.9) < 0.3 # The points on sphere_polydata_transformed are generally close to the torus.
+
+    torus_points = torus_polydata.GetPoints()
+    signed_distances = [
+        distance_from_sphere.FunctionValue(torus_points.GetPoint(i))
+        for i in range(torus_points.GetNumberOfPoints())
+    ]
+
+    # A point is *inside* iff the signed distance is negative, so ideally we should check that all signed_distance elements are negative.
+    # However we must leave a tolerance.
+    assert np.max(signed_distances) < 2 # With this tolerance, all torus points are inside rather than outside
+    assert skew(signed_distances) < 0 # The distribution of signed distances should be negatively skewed,
+    # the idea is that while most torus points are close to the sphere (signed distance hovering around 0)
+    # there is a tail in the distribution of signed distances consisting of points that are well inside the sphere


### PR DESCRIPTION
Close #149 

The goal of this PR is to add tooling to openlifu to create the skin surface interpolator needed for #147 (virtual fitting).

A useful bonus is that we will also get a skin surface model that can be used in transducer tracking.

Roughly the workflow from an MRI volume `array` and associated `affine` is this:

```mermaid
graph LR
A[array] --> B{"(1) fg mask"} --> C[mask] --> E{"(2) meshify"}
D[affine]-->E-->F[mesh]-->G{"(3)make<br>interpolator"}
G-->H[interpolator]
I[origin,<br>axes]-->H[interpolator]
```

The goal of this PR is to introduce algorithms (1), (2), and (3).

# (1) `compute_foreground_mask`

`compute_foreground_mask` is a python implementation of the BRAINSTools foreground masking algorithm, with some simplifications and (hopefully) improvements

- Original algorithm documentation: https://slicer.readthedocs.io/en/latest/user_guide/modules/brainsroiauto.html
- Original algorithm code: https://github.com/BRAINSia/BRAINSTools/tree/7c37d9e8c238f66f8a83f997d9c9bb659c494c90/BRAINSROIAuto

# (2) `create_closed_surface_from_labelmap`

`create_closed_surface_from_labelmap` is based on the closed surface representation functionality in Slicer's segmentation module.

- Original algorithm: https://github.com/Slicer/Slicer/blob/677932127c73a6c78654d4afd9458a655a4eef63/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx#L246-L476

# (3) `spherical_interpolator_from_mesh`

Here a "spherical interpolator" is a function that maps angles from a spherical coordinate system to r values (radial spherical coordinate values) by interpolating over a set of known values. It's essentially a "spherical plotter."

Summary of the algorithm:
- Transform the input mesh based on the desired origin and orientation of the spherical coordinate system.
- We will gather some points into a set $S$. For each point $P$ on the mesh consider the ray $\vec{OP}$ from the origin through $P$ and look at all the intersections of this ray $\vec{OP}$ with the mesh. If none of those intersections are further out from the origin than $P$ is, then we put $P$ into our set $S$.
- Using the spherical coordinates of the points in $S$, build a `scipy.interpolate.LinearNDInterpolator` that interpolates spherical $r$ values from the spherical $(\theta,\phi)$ values.
  - Problem: All the gathered $(\theta,\phi)$ values are likely strictly inside the square $[0,\pi]\times[-\pi,\pi]$, and `LinearNDInterpolator` does not _extrapolate_, and so angles close to the "seams" of the spherical coordinate system (the boundaries of that square) generate NaNs through the interpolator. The solution used here is to first clone the gathered points with appropriate angular shifts so as to cover those seams, and then give that larger set of points to the interpolator.
- Return the interpolator.

# Example visualized

Here is a visualization of the whole pipeline on an example (this one is of a defaced MRI):

![image](https://github.com/user-attachments/assets/42c40377-51d8-4b29-ae58-eb0fd828e403)

We start with a volume (shown as a slice), then we get a binary labelmap (shown as a slice), then we get a mesh (shown as a 3d render), and finally we get a spherical interpolator (shown applied to the vertices of a vtkSphereSource and then 3d rendered).