### PR TITLE
README.rst: Update Dev mode install instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ You can set up a development environment by running:
 ```bash
 python3 -m venv .venv
 source ./.venv/bin/activate
-pip install -v -e .[dev]
+pip install -v -e '.[dev]'
 ```
 
 If you have the
@@ -48,7 +48,7 @@ can instead do:
 
 ```bash
 py -m venv .venv
-py -m install -v -e .[dev]
+py -m install -v -e '.[dev]'
 ```
 
 # Post setup

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Dev mode
 ^^^^^^^^
 .. code:: sh
 
-   pip install -e .[dev]
+   pip install -e '.[dev]'
 
 Version control of database using DVC (Data Version Control)
 -------------------------------------------------------------


### PR DESCRIPTION
- Quoting `.[dev]` ensures compatibility with stricter shells (e.g., zsh). This resolves installation issues in dev mode with the following:

```
$ zsh --version
zsh 5.9 (arm64-apple-darwin24.0)
$ python3 --version
Python 3.13.1
```
Fixes #191 