### PR TITLE
Incorporate virtual fit results into Session (#179)

### DIFF
--- a/db_dvc.dvc
+++ b/db_dvc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: cccd6142d85cff1143fbdbf243fb8afe.dir
-  size: 803479658
-  nfiles: 82
+- md5: d82c778a093a87d824ea111b6afa62fe.dir
+  size: 803480757
+  nfiles: 83
   hash: md5
   path: db_dvc

--- a/db_dvc.dvc
+++ b/db_dvc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: f9fe2e59c4e854484b4e922a719bdfa7.dir
-  size: 803478753
-  nfiles: 83
+- md5: cccd6142d85cff1143fbdbf243fb8afe.dir
+  size: 803479658
+  nfiles: 82
   hash: md5
   path: db_dvc

--- a/scripts/standardize_database.py
+++ b/scripts/standardize_database.py
@@ -79,3 +79,9 @@ for subject_id in db.get_subject_ids():
         run_ids = db.get_run_ids(subject_id, session_id)
         db.write_run_ids(subject_id, session_id, run_ids)
         # (Runs are read only at the moment so it's just the runs.json and no individual runs to standardize)
+
+db.write_user_ids(db.get_user_ids())
+for user_id in db.get_user_ids():
+    user = db.load_user(user_id)
+    assert user_id == user.id
+    db.write_user(user, on_conflict=OnConflictOpts.OVERWRITE)

--- a/scripts/standardize_database.py
+++ b/scripts/standardize_database.py
@@ -1,0 +1,81 @@
+"""This is a utility script for developers to read in and write back out the dvc database.
+It is useful for standardizing the format of the example dvc data, and also for checking that the database
+mostly still works.
+
+To use this script, install openlifu to a python environment and then run the script providing the database folder as an argument:
+
+```
+python standardize_database.py db_dvc/
+```
+
+A couple of known issues to watch out for:
+- The date_modified of Sessions gets updated, as it should, when this is run. But we don't care about that change.
+- The netCDF simulation output files (.nc files) are modified for some reason each time they are written out. It's probably a similar
+  thing going on with some kind of timestamp being embedded in the file.
+"""
+
+import pathlib
+import shutil
+import sys
+import tempfile
+
+from openlifu.db import Database
+from openlifu.db.database import OnConflictOpts
+
+if len(sys.argv) != 2:
+    raise RuntimeError("Provide exactly one argument: the path to the database folder.")
+db = Database(sys.argv[1])
+
+db.write_protocol_ids(db.get_protocol_ids())
+for protocol_id in db.get_protocol_ids():
+    protocol = db.load_protocol(protocol_id)
+    assert protocol_id == protocol.id
+    db.write_protocol(protocol, on_conflict=OnConflictOpts.OVERWRITE)
+
+db.write_transducer_ids(db.get_transducer_ids())
+for transducer_id in db.get_transducer_ids():
+    transducer = db.load_transducer(transducer_id)
+    assert transducer_id == transducer.id
+    db.write_transducer(transducer, on_conflict=OnConflictOpts.OVERWRITE)
+
+db.write_subject_ids(db.get_subject_ids())
+for subject_id in db.get_subject_ids():
+    subject = db.load_subject(subject_id)
+    assert subject_id == subject.id
+    db.write_subject(subject, on_conflict=OnConflictOpts.OVERWRITE)
+
+    db.write_volume_ids(subject_id, db.get_volume_ids(subject_id))
+    for volume_id in db.get_volume_ids(subject_id):
+        volume_info = db.get_volume_info(subject_id, volume_id)
+        assert volume_info["id"] == volume_id
+        volume_data_abspath = pathlib.Path(volume_info["data_abspath"])
+
+        # The weird file move here is because of a quirk in Database:
+        # - you can't just edit the volume metadata, you have to write the metadata json and volume data file together
+        # - if you try to provide the volume_data_abspath as the data path you get a SameFileError from shutil which
+        # refuses to do the copy. These things can be fixed but it's a niche use case so I'd rather work around it in this script.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = pathlib.Path(tmpdir)
+            moved_vol_abspath = tmpdir / volume_data_abspath.name
+            shutil.move(volume_data_abspath, moved_vol_abspath)
+            db.write_volume(subject_id, volume_id, volume_info["name"], moved_vol_abspath, on_conflict=OnConflictOpts.OVERWRITE)
+
+    session_ids = db.get_session_ids(subject.id)
+    db.write_session_ids(subject_id, session_ids)
+    for session_id in session_ids:
+        session = db.load_session(subject, session_id)
+        assert session.id == session_id
+        assert session.subject_id == subject.id
+        db.write_session(subject, session, on_conflict=OnConflictOpts.OVERWRITE)
+
+        solution_ids = db.get_solution_ids(session.subject_id, session.id)
+        db.write_solution_ids(session, solution_ids)
+        for solution_id in solution_ids:
+            solution = db.load_solution(session, solution_id)
+            assert solution.id == solution_id
+            assert solution.simulation_result['p_min'].shape[0] == solution.num_foci()
+            db.write_solution(session, solution, on_conflict=OnConflictOpts.OVERWRITE)
+
+        run_ids = db.get_run_ids(subject_id, session_id)
+        db.write_run_ids(subject_id, session_id, run_ids)
+        # (Runs are read only at the moment so it's just the runs.json and no individual runs to standardize)

--- a/src/openlifu/db/database.py
+++ b/src/openlifu/db/database.py
@@ -153,15 +153,17 @@ class Database:
         if session.subject_id != subject.id:
             raise ValueError("IDs do not match between the given subject and the subject referenced in the session.")
 
-        # Validate the approved fit target ID
-        if (
-            session.virtual_fit_approval_for_target_id is not None
-            and session.virtual_fit_approval_for_target_id not in [target.id for target in session.targets]
-        ):
-            raise ValueError(
-                f"The provided virtual_fit_approval_for_target_id of {session.virtual_fit_approval_for_target_id} is not"
-                " in this session's list of targets."
-            )
+        # Validate the virtual fit results
+        for target_id, (_, transforms) in session.virtual_fit_results.items():
+            if target_id not in [target.id for target in session.targets]:
+                raise ValueError(
+                    f"The virtual_fit_results of session {session.id} references a target {target_id} that is not"
+                    " in the session's list of targets."
+                )
+            if len(transforms)<1:
+                raise ValueError(
+                    f"The virtual_fit_results of session {session.id} provides no transforms for target {target_id}."
+                )
 
         # Check if the session already exists in the database
         session_ids = self.get_session_ids(subject.id)

--- a/src/openlifu/db/session.py
+++ b/src/openlifu/db/session.py
@@ -139,7 +139,7 @@ class Session:
             for target_id,(approval,transforms) in d['virtual_fit_results'].items():
                 d['virtual_fit_results'][target_id] = (
                     approval,
-                    [ArrayTransform(t_dict["matrix"], t_dict["units"]) for t_dict in transforms],
+                    [ArrayTransform(np.array(t_dict["matrix"]), t_dict["units"]) for t_dict in transforms],
                 )
         if isinstance(d['markers'], list):
             if len(d['markers'])>0 and isinstance(d['markers'][0], dict):

--- a/src/openlifu/db/session.py
+++ b/src/openlifu/db/session.py
@@ -107,7 +107,6 @@ class Session:
         Create a Session from a file
 
         :param filename: Name of the file to read
-        :param db: Database object
         :returns: Session object
         """
         with open(filename) as f:
@@ -119,7 +118,6 @@ class Session:
         Create a session from a dictionary
 
         :param d: Dictionary of session parameters
-        :param db: Database object
         :returns: Session object
         """
         if 'date_created' in d:

--- a/tests/resources/example_db/subjects/example_subject/sessions/example_session/example_session.json
+++ b/tests/resources/example_db/subjects/example_subject/sessions/example_session/example_session.json
@@ -27,6 +27,21 @@
   },
   "attrs": {},
   "date_modified": "2024-04-09 11:27:30",
-  "virtual_fit_approval_for_target_id": "example_target",
+  "virtual_fit_results": {
+    "example_target": [
+      true,
+      [
+        {
+          "matrix": [
+            [1.1, 0, 0, 0],
+            [0, 1.2, 0, 0],
+            [0, 0, 1.3, 0],
+            [0, 0.05, 0, 1.4]
+          ],
+          "units": "mm"
+        }
+      ]
+    ]
+  },
   "transducer_tracking_approved": false
 }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -360,7 +360,7 @@ def test_write_session_mismatched_id(example_database: Database, example_subject
         (["an_existing_target_id"], [0], pytest.raises(ValueError, match="provides no transforms")),
     ]
 )
-def test_write_session_with_invalid_fit_approval(
+def test_write_session_with_invalid_fit_results(
     example_database: Database,
     example_subject: Subject,
     target_ids: List[str],
@@ -383,6 +383,13 @@ def test_write_session_with_invalid_fit_approval(
     )
     with expectation:
         example_database.write_session(example_subject, session)
+
+def test_session_arrays_read_correctly(example_session:Session):
+    """Verify that session data that is supposed to be array type is actually array type after reading from json"""
+    assert isinstance(example_session.array_transform.matrix, np.ndarray)
+    for _, (_, array_transforms) in example_session.virtual_fit_results.items():
+        for array_transform in array_transforms:
+            assert isinstance(array_transform.matrix, np.ndarray)
 
 @pytest.mark.parametrize("compact_representation", [True, False])
 def test_serialize_deserialize_session(example_session : Session, compact_representation:bool):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,7 +3,7 @@ import shutil
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 from unittest.mock import patch
 
 import numpy as np


### PR DESCRIPTION
Closes #179 

## `Session.virtual_fit_results`

Virtual fit results take the form of a dictionary mapping target IDs
to pairs `(approval, transforms)`, where:

- `approval` is a boolean indicating whether the virtual fit for that target has been approved, and
- `transforms` is a list of transducer transforms resulting from the virtual fit for that target.

The idea is that the list of transforms would be ordered from best to worst, and should of course
contain at least one transform.

## `standardize_database`

This is a utility script for developers to read in and write back out the dvc database. It is useful for standardizing the format of the example dvc data, and also for checking that the database mostly still works.

I have been using this on my own to help catch little discrepancies that pop up between the example data and the openlifu library -- I figured it's probably good to version control it here under a `scripts/` folder since it needs to evolve alongside the library.

To use this script, install openlifu to a python environment and then run the script providing the database folder as an argument:

```
python standardize_database.py db_dvc/
```

## Parallel SlicerOpenLIFU PR

(todo)

## Remaining to-do

- [x] Update DVC data
- [x] Start work on a parallel PR on SlicerOpenLIFU that makes the virtual fitting placeholder be compatible with this breaking change
  - It is here: https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/179