### PR TITLE
Fix DVC merge mistake

### DIFF
--- a/db_dvc.dvc
+++ b/db_dvc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: d82c778a093a87d824ea111b6afa62fe.dir
-  size: 803480757
+- md5: cf89344a4eee1e75c5be53d91941815e.dir
+  size: 803480549
   nfiles: 83
   hash: md5
   path: db_dvc


### PR DESCRIPTION
I made a mistake while merging where I overwrote some previous DVC changes in PR #212

This corrects that error, so it brings the DVC database to a manual merge of the [state it was in before](https://github.com/OpenwaterHealth/OpenLIFU-python/blob/26d4b257e06e92ad3cb377d1a197a51548249e3a/db_dvc.dvc) #212 was merged, and the state it was supposed to be in on my topic branch [before the flawed rebase](https://github.com/OpenwaterHealth/OpenLIFU-python/blob/589b0f6d62c6d89e9cde107e598e72584064f98d/db_dvc.dvc) of #212.