### PR TITLE
STYLE: Enforce import of __future__ annotations (#106)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,7 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+from __future__ import annotations
 
 import importlib.metadata
 

--- a/notebooks/LIFUTestWidget.py
+++ b/notebooks/LIFUTestWidget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import sys

--- a/notebooks/run_self_test.py
+++ b/notebooks/run_self_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from openlifu.io.LIFUInterface import LIFUInterface
 
 # set PYTHONPATH=%cd%\src;%PYTHONPATH%

--- a/notebooks/stress_test.py
+++ b/notebooks/stress_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 
 from openlifu.io.LIFUInterface import LIFUInterface

--- a/notebooks/test_first.py
+++ b/notebooks/test_first.py
@@ -21,6 +21,8 @@
 # Also, if you are using the original version, import `openlifu` takes _way_ longer (45s on my PC), presumably hanging on `import kwave`. For some reason, it wants to re-download the binaries every time, even though they are already present in the the installation directory. I've opened an issue on this: https://github.com/waltsims/k-wave-python/issues/366.
 
 # %%
+from __future__ import annotations
+
 import logging
 import sys
 

--- a/notebooks/test_nifti.py
+++ b/notebooks/test_nifti.py
@@ -14,6 +14,8 @@
 # ---
 
 # %%
+from __future__ import annotations
+
 modified_kwave_path = R'C:\Users\pjh7\git\k-wave-python'
 slicer_exe = R"C:\Users\pjh7\AppData\Local\NA-MIC\Slicer 5.2.2\Slicer.exe"
 import sys

--- a/notebooks/test_nucleo.py
+++ b/notebooks/test_nucleo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from openlifu.io.LIFUInterface import LIFUInterface
 
 # set PYTHONPATH=%cd%\src;%PYTHONPATH%

--- a/notebooks/test_registers.py
+++ b/notebooks/test_registers.py
@@ -14,6 +14,8 @@
 # ---
 
 # %%
+from __future__ import annotations
+
 import numpy as np
 
 from openlifu.io.LIFUTXDevice import (

--- a/notebooks/test_solution.py
+++ b/notebooks/test_solution.py
@@ -11,6 +11,7 @@
 #     language: python
 #     name: python3
 # ---
+from __future__ import annotations
 
 # +
 import numpy as np

--- a/notebooks/test_ti_cfg.py
+++ b/notebooks/test_ti_cfg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from openlifu.io.LIFUInterface import LIFUInterface
 
 # set PYTHONPATH=%cd%\src;%PYTHONPATH%

--- a/notebooks/test_transmitter.py
+++ b/notebooks/test_transmitter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from openlifu.io.LIFUInterface import LIFUInterface
 
 # set PYTHONPATH=%cd%\src;%PYTHONPATH%

--- a/notebooks/test_updated_if.py
+++ b/notebooks/test_updated_if.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from openlifu.io.LIFUInterface import LIFUInterface
 
 # set PYTHONPATH=%cd%\src;%PYTHONPATH%

--- a/notebooks/test_updated_pwr.py
+++ b/notebooks/test_updated_pwr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from openlifu.io.LIFUInterface import LIFUInterface
 
 # set PYTHONPATH=%cd%\src;%PYTHONPATH%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,6 @@ ignore = [
   # Exceptions below are specific to this project.
   # They may be relaxed later in future code improvements.
 
-  "I002", # Missing required import: `from __future__ import annotations`
   "E402", # Module level import not at top of file
   "ARG002", # Unused method argument: `id`
   "RET504", # Unnecessary assignment to `dist` before `return` statement

--- a/scripts/standardize_database.py
+++ b/scripts/standardize_database.py
@@ -13,6 +13,7 @@ A couple of known issues to watch out for:
 - The netCDF simulation output files (.nc files) are modified for some reason each time they are written out. It's probably a similar
   thing going on with some kind of timestamp being embedded in the file.
 """
+from __future__ import annotations
 
 import pathlib
 import shutil

--- a/src/openlifu/bf/__init__.py
+++ b/src/openlifu/bf/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .apod_methods import ApodizationMethod
 from .delay_methods import DelayMethod
 from .focal_patterns import FocalPattern, SinglePoint, Wheel

--- a/src/openlifu/bf/apod_methods/__init__.py
+++ b/src/openlifu/bf/apod_methods/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .apodmethod import ApodizationMethod
 from .maxangle import MaxAngle
 from .piecewiselinear import PiecewiseLinear

--- a/src/openlifu/bf/apod_methods/apodmethod.py
+++ b/src/openlifu/bf/apod_methods/apodmethod.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import xarray as xa
@@ -13,7 +14,7 @@ from openlifu.xdc import Transducer
 @dataclass
 class ApodizationMethod(ABC):
     @abstractmethod
-    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:Optional[np.ndarray]=None):
+    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:np.ndarray | None=None):
         pass
 
     def to_dict(self):

--- a/src/openlifu/bf/apod_methods/maxangle.py
+++ b/src/openlifu/bf/apod_methods/maxangle.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import xarray as xa
@@ -13,7 +14,7 @@ from openlifu.xdc import Transducer
 class MaxAngle(ApodizationMethod):
     max_angle: float = 30.0
     units: str = "deg"
-    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:Optional[np.ndarray]=None):
+    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:np.ndarray | None=None):
         target_pos = target.get_position(units="m")
         matrix = transform if transform is not None else np.eye(4)
         angles = np.array([el.angle_to_point(target_pos, units="m", matrix=matrix, return_as=self.units) for el in arr.elements])

--- a/src/openlifu/bf/apod_methods/piecewiselinear.py
+++ b/src/openlifu/bf/apod_methods/piecewiselinear.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import xarray as xa
@@ -14,7 +15,7 @@ class PiecewiseLinear(ApodizationMethod):
     zero_angle: float = 90.0
     rolloff_angle: float = 45.0
     units: str = "deg"
-    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:Optional[np.ndarray]=None):
+    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:np.ndarray | None=None):
         target_pos = target.get_position(units="m")
         matrix = transform if transform is not None else np.eye(4)
         angles = np.array([el.angle_to_point(target_pos, units="m", matrix=matrix, return_as=self.units) for el in arr.elements])

--- a/src/openlifu/bf/apod_methods/uniform.py
+++ b/src/openlifu/bf/apod_methods/uniform.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import xarray as xa
@@ -12,5 +13,5 @@ from openlifu.xdc import Transducer
 @dataclass
 class Uniform(ApodizationMethod):
     value = 1
-    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:Optional[np.ndarray]=None):
+    def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:np.ndarray | None=None):
         return np.full(arr.numelements(), self.value)

--- a/src/openlifu/bf/delay_methods/__init__.py
+++ b/src/openlifu/bf/delay_methods/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .delaymethod import DelayMethod
 from .direct import Direct
 

--- a/src/openlifu/bf/delay_methods/delaymethod.py
+++ b/src/openlifu/bf/delay_methods/delaymethod.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import xarray as xa
@@ -13,7 +14,7 @@ from openlifu.xdc import Transducer
 @dataclass
 class DelayMethod(ABC):
     @abstractmethod
-    def calc_delays(self, arr: Transducer, target: Point, params: xa.Dataset, transform:Optional[np.ndarray]=None):
+    def calc_delays(self, arr: Transducer, target: Point, params: xa.Dataset, transform:np.ndarray | None=None):
         pass
 
     def to_dict(self):

--- a/src/openlifu/bf/delay_methods/direct.py
+++ b/src/openlifu/bf/delay_methods/direct.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import xarray as xa
@@ -12,7 +13,7 @@ from openlifu.xdc import Transducer
 @dataclass
 class Direct(DelayMethod):
     c0: float = 1480.0
-    def calc_delays(self, arr: Transducer, target: Point, params: Optional[xa.Dataset]=None, transform:Optional[np.ndarray]=None):
+    def calc_delays(self, arr: Transducer, target: Point, params: xa.Dataset | None=None, transform:np.ndarray | None=None):
         if params is None:
             c = self.c0
         else:

--- a/src/openlifu/bf/focal_patterns/__init__.py
+++ b/src/openlifu/bf/focal_patterns/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .focal_pattern import FocalPattern
 from .single import SinglePoint
 from .wheel import Wheel

--- a/src/openlifu/bf/focal_patterns/focal_pattern.py
+++ b/src/openlifu/bf/focal_patterns/focal_pattern.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 

--- a/src/openlifu/bf/focal_patterns/single.py
+++ b/src/openlifu/bf/focal_patterns/single.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from openlifu.bf.focal_patterns import FocalPattern

--- a/src/openlifu/bf/focal_patterns/wheel.py
+++ b/src/openlifu/bf/focal_patterns/wheel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import numpy as np

--- a/src/openlifu/bf/pulse.py
+++ b/src/openlifu/bf/pulse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import numpy as np

--- a/src/openlifu/bf/sequence.py
+++ b/src/openlifu/bf/sequence.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 import pandas as pd

--- a/src/openlifu/db/__init__.py
+++ b/src/openlifu/db/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .database import Database
 from .session import Session
 from .subject import Subject

--- a/src/openlifu/db/database.py
+++ b/src/openlifu/db/database.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import glob
 import json
@@ -6,7 +7,7 @@ import os
 import shutil
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 import h5py
 
@@ -23,7 +24,7 @@ OnConflictOpts = Enum('OnConflictOpts', ['ERROR', 'OVERWRITE', 'SKIP'])
 PathLike = Union[str, os.PathLike]
 
 class Database:
-    def __init__(self, path: Optional[str] = None):
+    def __init__(self, path: str | None = None):
         if path is None:
             path = Database.get_default_path()
         self.path = os.path.normpath(path)
@@ -273,8 +274,8 @@ class Database:
     def write_transducer(
             self,
             transducer,
-            registration_surface_model_filepath: Optional[PathLike] = None,
-            transducer_body_model_filepath: Optional[PathLike] = None,
+            registration_surface_model_filepath: PathLike | None = None,
+            transducer_body_model_filepath: PathLike | None = None,
             on_conflict: OnConflictOpts=OnConflictOpts.ERROR,
     ) -> None:
         """ Writes a transducer object to database and copies the affiliated transducer data files to the database if provided. When a transducer that is already present in the database is being re-written,
@@ -395,7 +396,7 @@ class Database:
 
         self.logger.info(f"Added volume with ID {volume_id} for subject {subject_id} to the database.")
 
-    def write_photoscan(self, subject_id, session_id, photoscan: Photoscan, model_data_filepath: Optional[str] = None, texture_data_filepath: Optional[str] = None, mtl_data_filepath: Optional[str] = None, on_conflict=OnConflictOpts.ERROR):
+    def write_photoscan(self, subject_id, session_id, photoscan: Photoscan, model_data_filepath: str | None = None, texture_data_filepath: str | None = None, mtl_data_filepath: str | None = None, on_conflict=OnConflictOpts.ERROR):
         """ Writes a photoscan object to database and copies the associated model and texture data filepaths that are required for generating a photoscan into the database.
         .mtl files are not required for generating a photoscan but can be provided if present.
         When a photoscan that is already present in the database is being re-written,the associated model and texture files do not need to be provided """
@@ -714,7 +715,7 @@ class Database:
             return photoscan, (model_data, texture_data)
         return photoscan
 
-    def get_transducer_absolute_filepaths(self, transducer_id:str) -> Dict[str,Optional[str]]:
+    def get_transducer_absolute_filepaths(self, transducer_id:str) -> Dict[str,str | None]:
         """ Returns the absolute filepaths to the model data files i.e. transducer body and registration surface
         model files affiliated with the transducer, with ID `transducer_id`. Unlike `load_transducer`, which
         specifies the relative paths to the model datafiles along with other transducer attributes, this function
@@ -768,7 +769,7 @@ class Database:
         sys = UltrasoundSystem.from_file(sys_filename)
         return sys
 
-    def load_transducer(self, transducer_id) -> "Transducer":
+    def load_transducer(self, transducer_id) -> Transducer:
         """Given a transducer_id, reads the corresponding transducer file from database and returns a transducer object.
         Note: the transducer object includes the relative path to the affiliated transducer model data. `get_transducer_absolute_filepaths`, should
         be used to obtain the absolute data filepaths based on the Database directory path.
@@ -1077,7 +1078,7 @@ class Database:
         return Path(Database.get_default_user_dir()) / "Documents" / "db"
 
     @staticmethod
-    def initialize_empty_database(database_filepath : PathLike) -> "Database":
+    def initialize_empty_database(database_filepath : PathLike) -> Database:
         """
         Initializes an empty database at the given database_filepath
         """

--- a/src/openlifu/db/session.py
+++ b/src/openlifu/db/session.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import copy
 import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 import numpy as np
 
@@ -33,13 +35,13 @@ class Session:
     to use, potential targets for sonication, and a transducer situated in the patient space.
     """
 
-    id: Optional[str] = None
+    id: str | None = None
     """ID of this session"""
 
-    subject_id: Optional[str] = None
+    subject_id: str | None = None
     """ID of the parent subject of this session"""
 
-    name: Optional[str] = None
+    name: str | None = None
     """Session name"""
 
     date_created: datetime = field(default_factory=datetime.now)
@@ -48,13 +50,13 @@ class Session:
     date_modified: datetime = field(default_factory=datetime.now)
     """Date of modification of the session"""
 
-    protocol_id: Optional[str] = None
+    protocol_id: str | None = None
     """ID of the protocol used for this session"""
 
-    volume_id: Optional[str] = None
+    volume_id: str | None = None
     """ID of the subject volume associated with this session"""
 
-    transducer_id: Optional[str] = None
+    transducer_id: str | None = None
     """ID of the transducer associated with this session"""
 
     array_transform: ArrayTransform = field(default_factory=lambda : ArrayTransform(np.eye(4),"mm"))
@@ -81,7 +83,7 @@ class Session:
     only. None of the other transforms in the list are considered to be approved.
     """
 
-    transducer_tracking_approved: Optional[bool] = False
+    transducer_tracking_approved: bool | None = False
     """Approval state of transducer tracking. `True` means the user has provided some kind of
     confirmation that the transducer transform in this session agrees with reality."""
 
@@ -173,7 +175,7 @@ class Session:
         return d
 
     @staticmethod
-    def from_json(json_string : str) -> "Session":
+    def from_json(json_string : str) -> Session:
         """Load a Session from a json string"""
         return Session.from_dict(json.loads(json_string))
 
@@ -201,7 +203,7 @@ class Session:
         with open(filename, 'w') as file:
             file.write(self.to_json(compact=False))
 
-    def update_modified_time(self, time: Optional[datetime] = None):
+    def update_modified_time(self, time: datetime | None = None):
         if time is None:
             time = datetime.now()
         self.date_modified = time

--- a/src/openlifu/db/subject.py
+++ b/src/openlifu/db/subject.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 from openlifu.util.dict_conversion import DictMixin
 from openlifu.util.strings import sanitize
@@ -17,8 +18,8 @@ class Subject(DictMixin):
     ivar volumes: List of volume IDs
     ivar attrs: Dictionary of attributes
     """
-    id: Optional[str] = None
-    name: Optional[str] = None
+    id: str | None = None
+    name: str | None = None
     attrs: dict = field(default_factory=dict)
 
     def __post_init__(self):

--- a/src/openlifu/db/user.py
+++ b/src/openlifu/db/user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import dataclass, field
@@ -26,7 +28,7 @@ class User:
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
-    def from_dict(d : Dict[str,Any]) -> "User":
+    def from_dict(d : Dict[str,Any]) -> User:
         return User(**d)
 
     def to_dict(self):
@@ -45,7 +47,7 @@ class User:
         return User.from_dict(d)
 
     @staticmethod
-    def from_json(json_string : str) -> "User":
+    def from_json(json_string : str) -> User:
         """Load a User from a json string"""
         return User.from_dict(json.loads(json_string))
 

--- a/src/openlifu/geo.py
+++ b/src/openlifu/geo.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import copy
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 import numpy as np
 import vtk
@@ -27,7 +29,7 @@ class Point:
     def copy(self):
         return copy.deepcopy(self)
 
-    def get_position(self, dim=None, units: Optional[str] =None):
+    def get_position(self, dim=None, units: str | None =None):
         units = self.units if units is None else units
         scl = getunitconversion(self.units, units)
         if dim is None:
@@ -85,8 +87,8 @@ class Point:
 
     def transform(self,
                   matrix: np.ndarray,
-                  units: Optional[str] = None,
-                  new_dims: Optional[Tuple[str, str, str]]=None):
+                  units: str | None = None,
+                  new_dims: Tuple[str, str, str] | None=None):
         if units is not None:
             self.rescale(units)
         self.position = np.dot(matrix, np.append(self.position, 1.0))[:3]
@@ -118,7 +120,7 @@ class Point:
         return Point(**point_data)
 
     @staticmethod
-    def from_json(json_string : str) -> "Point":
+    def from_json(json_string : str) -> Point:
         """Load a Point from a json string"""
         return Point.from_dict(json.loads(json_string))
 

--- a/src/openlifu/io/LIFUConfig.py
+++ b/src/openlifu/io/LIFUConfig.py
@@ -1,5 +1,7 @@
 
 # Packet Types
+from __future__ import annotations
+
 OW_ACK = 0xE0
 OW_NAK = 0xE1
 OW_CMD = 0xE2

--- a/src/openlifu/io/LIFUInterface.py
+++ b/src/openlifu/io/LIFUInterface.py
@@ -109,7 +109,7 @@ class LIFUInterface:
         return tx_connected, hv_connected
 
     def set_solution(self,
-                     solution: Solution|Dict,
+                     solution: Solution | Dict,
                      profile_index:int=1,
                      profile_increment:bool=True) -> bool:
         """

--- a/src/openlifu/io/LIFUSignal.py
+++ b/src/openlifu/io/LIFUSignal.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class LIFUSignal:
     def __init__(self):
         # Initialize a list to store connected slots (callback functions)

--- a/src/openlifu/io/LIFUUart.py
+++ b/src/openlifu/io/LIFUUart.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import queue

--- a/src/openlifu/io/__init__.py
+++ b/src/openlifu/io/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from openlifu.io.LIFUInterface import LIFUInterface, LIFUInterfaceStatus
 
 __all__ = [

--- a/src/openlifu/photoscan.py
+++ b/src/openlifu/photoscan.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 import numpy as np
 import OpenEXR
@@ -19,13 +20,13 @@ class Photoscan:
     name: str = "Photoscan"
     """Photoscan name"""
 
-    model_filename: Optional[str] =  None
+    model_filename: str | None =  None
     """Relative path to model"""
 
-    texture_filename: Optional[str] = None
+    texture_filename: str | None = None
     """Relative path to texture image"""
 
-    mtl_filename: Optional[str] = None
+    mtl_filename: str | None = None
     """Relative path to materials file"""
 
     photoscan_approved: bool = False
@@ -33,7 +34,7 @@ class Photoscan:
     confirmation that the photoscan is good enough to be used."""
 
     @staticmethod
-    def from_json(json_string: str) -> "Photoscan":
+    def from_json(json_string: str) -> Photoscan:
         """Load a Photoscan from a json string"""
         return Photoscan.from_dict(json.loads(json_string))
 
@@ -52,7 +53,7 @@ class Photoscan:
             return json.dumps(self.to_dict(), indent=4, cls=PYFUSEncoder)
 
     @staticmethod
-    def from_dict(d:Dict) -> "Photoscan":
+    def from_dict(d:Dict) -> Photoscan:
         """
         Create a Photoscan from a dictionary
         param d: Dictionary of photoscan parameters.
@@ -69,7 +70,7 @@ class Photoscan:
         return d
 
     @staticmethod
-    def from_file(filename) -> "Photoscan":
+    def from_file(filename) -> Photoscan:
         """
         Load a Photoscan from a metadata file
         :param filename: Name of the file

--- a/src/openlifu/plan/__init__.py
+++ b/src/openlifu/plan/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .protocol import Protocol
 from .run import Run
 from .solution import Solution

--- a/src/openlifu/plan/protocol.py
+++ b/src/openlifu/plan/protocol.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import math
@@ -6,7 +8,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 import xarray as xa
@@ -70,7 +72,7 @@ class Protocol:
         self.logger = logging.getLogger(__name__)
 
     @staticmethod
-    def from_dict(d : Dict[str,Any]) -> "Protocol":
+    def from_dict(d : Dict[str,Any]) -> Protocol:
         d["pulse"] = bf.Pulse.from_dict(d.get("pulse", {}))
         d["sequence"] = bf.Sequence.from_dict(d.get("sequence", {}))
         d["focal_pattern"] = bf.FocalPattern.from_dict(d.get("focal_pattern", {}))
@@ -119,7 +121,7 @@ class Protocol:
         return delays, apod
 
     @staticmethod
-    def from_json(json_string : str) -> "Protocol":
+    def from_json(json_string : str) -> Protocol:
         """Load a Protocol from a json string"""
         return Protocol.from_dict(json.loads(json_string))
 
@@ -187,14 +189,14 @@ class Protocol:
         self,
         target: Point,
         transducer: Transducer,
-        volume: Optional[xa.DataArray] = None,
-        session: Optional[Session] = None,
+        volume: xa.DataArray | None = None,
+        session: Session | None = None,
         simulate: bool = True,
         scale: bool = True,
-        sim_options: Optional[sim.SimSetup] = None,
-        analysis_options: Optional[SolutionAnalysisOptions] = None,
+        sim_options: sim.SimSetup | None = None,
+        analysis_options: SolutionAnalysisOptions | None = None,
         on_pulse_mismatch: OnPulseMismatchAction = OnPulseMismatchAction.ERROR,
-        use_gpu: Optional[bool] = None,
+        use_gpu: bool | None = None,
     ) -> Tuple[Solution, xa.DataArray, SolutionAnalysis]:
         """Calculate the solution and aggregated k-wave simulation outputs.
 

--- a/src/openlifu/plan/run.py
+++ b/src/openlifu/plan/run.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from openlifu.util.json import PYFUSEncoder
 
@@ -12,22 +14,22 @@ class Run:
     Class representing a run
     """
 
-    id: Optional[str] = None
+    id: str | None = None
     """id: ID of the run"""
 
-    name: Optional[str] = None
+    name: str | None = None
     """name: Name of the run"""
 
-    success_flag: Optional[bool] = None
+    success_flag: bool | None = None
     """success_flag: True when run was successful, False otherwise"""
 
-    note: Optional[str] = None
+    note: str | None = None
     """note: large text containing notes about the run"""
 
-    session_id: Optional[str] = None
+    session_id: str | None = None
     """session_id: session id"""
 
-    solution_id: Optional[str] = None
+    solution_id: str | None = None
     """solution_id: solution id"""
 
     @staticmethod
@@ -43,12 +45,12 @@ class Run:
         return Run.from_dict(d)
 
     @staticmethod
-    def from_json(json_string : str) -> "Run":
+    def from_json(json_string : str) -> Run:
         """Load a Run from a json string"""
         return Run.from_dict(json.loads(json_string))
 
     @staticmethod
-    def from_dict(d : Dict[str, Any]) -> "Run":
+    def from_dict(d : Dict[str, Any]) -> Run:
         return Run(**d)
 
     def to_dict(self):

--- a/src/openlifu/plan/solution.py
+++ b/src/openlifu/plan/solution.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import base64
 import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import numpy as np
 import xarray as xa
@@ -40,10 +42,10 @@ class Solution:
     name: str = "Solution"
     """Name of this solution"""
 
-    protocol_id: Optional[str] = None  # this used to be called plan_id in the matlab code
+    protocol_id: str | None = None  # this used to be called plan_id in the matlab code
     """ID of the protocol that was used when generating this solution"""
 
-    transducer_id: Optional[str] = None
+    transducer_id: str | None = None
     """ID of the transducer that was used when generating this solution"""
 
     date_created: datetime = field(default_factory=datetime.now)
@@ -52,10 +54,10 @@ class Solution:
     description: str = ""
     """Description of this solution"""
 
-    delays: Optional[np.ndarray] = None
+    delays: np.ndarray | None = None
     """Vectors of time delays to steer the beam. Shape is (number of foci, number of transducer elements)."""
 
-    apodizations: Optional[np.ndarray] = None
+    apodizations: np.ndarray | None = None
     """Vectors of apodizations to steer the beam. Shape is (number of foci, number of transducer elements)."""
 
     pulse: Pulse = field(default_factory=Pulse)
@@ -74,7 +76,7 @@ class Solution:
     # I believe this was only needed in the matlab software because solutions were organized by target rather
     # than having their own unique solution ID. We do have unique solution IDs so it's possible we don't need
     # this target attribute at all here. Keeping it here for now just in case.
-    target: Optional[Point] = None
+    target: Point | None = None
     """The ultimate target of this sonication. This sonication solution is focused on one focal point
     in a pattern that is centered on this target."""
 
@@ -367,7 +369,7 @@ class Solution:
             return json.dumps(solution_dict, indent=4, cls=PYFUSEncoder)
 
     @staticmethod
-    def from_json(json_string : str, simulation_result: Optional[xa.Dataset]=None) -> "Solution":
+    def from_json(json_string : str, simulation_result: xa.Dataset | None=None) -> Solution:
         """Load a Solution from a json string.
 
         Args:
@@ -411,7 +413,7 @@ class Solution:
 
         return Solution(**solution_dict)
 
-    def to_files(self, json_filepath:Path, nc_filepath:Optional[Path]=None) -> None:
+    def to_files(self, json_filepath:Path, nc_filepath:Path | None=None) -> None:
         """Save the solution to json and netCDF files.
 
         json_filepath: where to save the json file with all data except the simulation results dataset
@@ -430,7 +432,7 @@ class Solution:
         self.simulation_result.to_netcdf(nc_filepath, engine='h5netcdf')
 
     @staticmethod
-    def from_files(json_filepath:Path, nc_filepath:Optional[Path]=None):
+    def from_files(json_filepath:Path, nc_filepath:Path | None=None):
         """Read solution from json and netCDF files.
 
         json_filepath: solution json file location, containing all data except the simulation results dataset

--- a/src/openlifu/plan/solution_analysis.py
+++ b/src/openlifu/plan/solution_analysis.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass, field
-from typing import Optional, Tuple
+from typing import Tuple
 
 import numpy as np
 import xarray as xa
@@ -26,13 +28,13 @@ class SolutionAnalysis(DictMixin):
     global_pnp_MPa: list[float] = field(default_factory=list)
     global_isppa_Wcm2: list[float] = field(default_factory=list)
     p0_Pa: list[float] = field(default_factory=list)
-    TIC: Optional[float] = None
-    power_W: Optional[float] = None
-    MI: Optional[float] = None
-    global_ispta_mWcm2: Optional[float] = None
+    TIC: float | None = None
+    power_W: float | None = None
+    MI: float | None = None
+    global_ispta_mWcm2: float | None = None
 
     @staticmethod
-    def from_json(json_string : str) -> "SolutionAnalysis":
+    def from_json(json_string : str) -> SolutionAnalysis:
         """Load a SolutionAnalysis from a json string"""
         return SolutionAnalysis.from_dict(json.loads(json_string))
 
@@ -202,8 +204,8 @@ def interp_transformed_axis(
     focus,
     dim,
     origin=DEFAULT_ORIGIN,
-    min_offset:Optional[float]=None,
-    max_offset:Optional[float]=None,
+    min_offset:float | None=None,
+    max_offset:float | None=None,
 ) -> xa.DataArray:
     """Interpolate data along a focal coordinate system axis.
 
@@ -248,8 +250,8 @@ def get_beam_bounds(
     dim,
     cutoff:float,
     origin=DEFAULT_ORIGIN,
-    min_offset:Optional[float]=None,
-    max_offset:Optional[float]=None,
+    min_offset:float | None=None,
+    max_offset:float | None=None,
 ) -> Tuple[float, float]:
     """Determine how far along a focal coordinate system axis a DataArray's value stays above a certain cutoff.
 
@@ -294,10 +296,10 @@ def get_beamwidth(
     da: xa.DataArray,
     focus,
     dim,
-    cutoff:Optional[float]=None,
+    cutoff:float | None=None,
     origin=DEFAULT_ORIGIN,
-    min_offset:Optional[float]=None,
-    max_offset:Optional[float]=None
+    min_offset:float | None=None,
+    max_offset:float | None=None
 ) -> float:
     """Determine the FWHM (or differently thresholded width) of a DataArray along a focal coordinate system axis.
 

--- a/src/openlifu/plan/target_constraints.py
+++ b/src/openlifu/plan/target_constraints.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 

--- a/src/openlifu/seg/__init__.py
+++ b/src/openlifu/seg/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .material import AIR, MATERIALS, SKULL, STANDOFF, TISSUE, WATER, Material
 from .seg_methods import SegmentationMethod
 

--- a/src/openlifu/seg/material.py
+++ b/src/openlifu/seg/material.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Tuple
 

--- a/src/openlifu/seg/seg_methods/__init__.py
+++ b/src/openlifu/seg/seg_methods/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from . import seg_method
 from .seg_method import SegmentationMethod, UniformSegmentation
 from .tissue import Tissue

--- a/src/openlifu/seg/seg_methods/seg_method.py
+++ b/src/openlifu/seg/seg_methods/seg_method.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import copy
 from abc import abstractmethod
 from dataclasses import asdict, dataclass, field
-from typing import Optional
 
 import numpy as np
 import xarray as xa
@@ -44,11 +45,11 @@ class SegmentationMethod:
             class_constructor = module_dict[short_classname]
             return class_constructor(**d)
 
-    def _material_indices(self, materials: Optional[dict] = None):
+    def _material_indices(self, materials: dict | None = None):
         materials = self.materials if materials is None else materials
         return {material_id: i for i, material_id in enumerate(materials.keys())}
 
-    def _map_params(self, seg: xa.DataArray, materials: Optional[dict] = None):
+    def _map_params(self, seg: xa.DataArray, materials: dict | None = None):
         materials = self.materials if materials is None else materials
         material_dict = self._material_indices(materials=materials)
         params = xa.Dataset()
@@ -63,7 +64,7 @@ class SegmentationMethod:
         params.attrs['ref_material'] = ref_mat
         return params
 
-    def seg_params(self, volume: xa.DataArray, materials: Optional[dict] = None):
+    def seg_params(self, volume: xa.DataArray, materials: dict | None = None):
         materials = self.materials if materials is None else materials
         seg = self._segment(volume)
         params = self._map_params(seg, materials=materials)

--- a/src/openlifu/seg/seg_methods/tissue.py
+++ b/src/openlifu/seg/seg_methods/tissue.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from openlifu.seg.seg_methods.seg_method import UniformSegmentation

--- a/src/openlifu/seg/seg_methods/water.py
+++ b/src/openlifu/seg/seg_methods/water.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from openlifu.seg.seg_methods.seg_method import UniformSegmentation

--- a/src/openlifu/seg/skinseg.py
+++ b/src/openlifu/seg/skinseg.py
@@ -11,8 +11,9 @@ foreground_mask_vtk_image = vtk_img_from_array_and_affine(foreground_mask_array,
 skin_mesh = create_closed_surface_from_labelmap(foreground_mask_vtk_image)
 skin_interpolator = spherical_interpolator_from_mesh(skin_mesh, origin)
 """
+from __future__ import annotations
 
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Tuple
 
 import numpy as np
 import skimage.filters
@@ -252,7 +253,7 @@ def spherical_to_cartesian(r: float, th:float, ph:float) -> Tuple[float, float, 
 def spherical_interpolator_from_mesh(
     surface_mesh: vtk.vtkPolyData,
     origin: Tuple[float, float, float] = (0.,0.,0.),
-    xyz_direction_columns: Optional[np.ndarray] = None,
+    xyz_direction_columns: np.ndarray | None = None,
     dist_tolerance: float = 0.0001
 ) -> Callable[[float, float], float]:
     """Create a spherical interpolator from a vtkPolyData.

--- a/src/openlifu/sim/__init__.py
+++ b/src/openlifu/sim/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from . import kwave_if
 from .kwave_if import run_simulation
 from .sim_setup import SimSetup

--- a/src/openlifu/sim/kwave_if.py
+++ b/src/openlifu/sim/kwave_if.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import List, Optional
+from typing import List
 
 import kwave
 import kwave.data
@@ -67,8 +69,8 @@ def get_source(kgrid, karray, source_sig):
 
 def run_simulation(arr: xdc.Transducer,
                    params: xa.Dataset,
-                   delays: Optional[np.ndarray] = None,
-                   apod: Optional[np.ndarray] = None,
+                   delays: np.ndarray | None = None,
+                   apod: np.ndarray | None = None,
                    freq: float = 1e6,
                    cycles: float = 20,
                    amplitude: float = 1,

--- a/src/openlifu/util/checkgpu.py
+++ b/src/openlifu/util/checkgpu.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pynvml import nvmlDeviceGetCount, nvmlInit, nvmlShutdown
 
 

--- a/src/openlifu/util/dict_conversion.py
+++ b/src/openlifu/util/dict_conversion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Type, TypeVar
 

--- a/src/openlifu/util/json.py
+++ b/src/openlifu/util/json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from datetime import datetime
 from pathlib import Path

--- a/src/openlifu/util/strings.py
+++ b/src/openlifu/util/strings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import Literal
 

--- a/src/openlifu/util/units.py
+++ b/src/openlifu/util/units.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 from xarray import Dataset
 

--- a/src/openlifu/xdc/__init__.py
+++ b/src/openlifu/xdc/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from . import element, transducer
 from .element import Element
 from .transducer import Transducer

--- a/src/openlifu/xdc/element.py
+++ b/src/openlifu/xdc/element.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 from collections.abc import Iterable
 from dataclasses import dataclass, field

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,5 @@
 """Helper utilities for unit tests"""
+from __future__ import annotations
 
 from dataclasses import fields, is_dataclass
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import logging
 import shutil
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 from unittest.mock import patch
 
 import numpy as np
@@ -682,7 +684,7 @@ def test_write_transducer(example_database:Database, example_transducer: Transdu
 
 @pytest.mark.parametrize("registration_surface_path", [None, "test_db_files/example_registration_surface.obj"])
 @pytest.mark.parametrize("transducer_body_path", [None, "test_db_files/example_transducer_body.obj"])
-def test_get_transducer_absolute_filepaths(example_database, tmp_path: Path, registration_surface_path: Optional[str], transducer_body_path: Optional[str]):
+def test_get_transducer_absolute_filepaths(example_database, tmp_path: Path, registration_surface_path: str | None, transducer_body_path: str | None):
     transducer = Transducer(id="transducer_for_test_get_transducer_absolute_filepaths")
 
     registration_surface = Path(tmp_path / registration_surface_path) if registration_surface_path else None

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 from openlifu.geo import Point

--- a/tests/test_offset_grid.py
+++ b/tests/test_offset_grid.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from xarray import DataArray, Dataset

--- a/tests/test_photoscans.py
+++ b/tests/test_photoscans.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shutil
 from pathlib import Path
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import numpy as np
 import pytest

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import pytest
@@ -97,7 +98,7 @@ def test_calc_solution_use_gpu(
     mocker:MockerFixture,
     example_protocol:Protocol,
     example_transducer:Transducer,
-    use_gpu:Optional[bool],
+    use_gpu:bool | None,
     gpu_is_available:bool,
 ):
     """Test that the correct value of use_gpu is passed to the simulation runner"""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_seg_method.py
+++ b/tests/test_seg_method.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import pytest
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from helpers import dataclasses_are_equal
 
 from openlifu import Sequence

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import xarray
 
 import openlifu

--- a/tests/test_skinseg.py
+++ b/tests/test_skinseg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 import numpy as np

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from pathlib import Path
 

--- a/tests/test_sonication_control_mock.py
+++ b/tests/test_sonication_control_mock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 

--- a/tests/test_transducer.py
+++ b/tests/test_transducer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from xarray import DataArray, Dataset

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
- Remove the exception to [this linting rule](https://docs.astral.sh/ruff/rules/missing-required-import/)
- Allow ruff to make bulk changes to satisfy the new rule

Making the linter more strict on this makes it clear how to fix type annotation complaints, avoiding some confusing situations
