### PR TITLE
Pack LIFUInterface status into enum (#228)

### DIFF
--- a/src/openlifu/io/LIFUInterface.py
+++ b/src/openlifu/io/LIFUInterface.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from enum import Enum
 from typing import Dict
 
 from openlifu.io.LIFUHVController import HVController
@@ -10,16 +11,18 @@ from openlifu.io.LIFUTXDevice import TxDevice
 from openlifu.io.LIFUUart import LIFUUart
 from openlifu.plan.solution import Solution
 
-STATUS_COMMS_ERROR = -1
-STATUS_SYS_OFF = 0
-STATUS_SYS_POWERUP = 1
-STATUS_SYS_ON = 2
-STATUS_PROGRAMMING = 3
-STATUS_READY = 4
-STATUS_NOT_READY = 5
-STATUS_RUNNING = 6
-STATUS_FINISHED = 7
-STATUS_ERROR = 8
+
+class LIFUInterfaceStatus(Enum):
+    STATUS_COMMS_ERROR = -1
+    STATUS_SYS_OFF = 0
+    STATUS_SYS_POWERUP = 1
+    STATUS_SYS_ON = 2
+    STATUS_PROGRAMMING = 3
+    STATUS_READY = 4
+    STATUS_NOT_READY = 5
+    STATUS_RUNNING = 6
+    STATUS_FINISHED = 7
+    STATUS_ERROR = 8
 
 logger = logging.getLogger(__name__)
 
@@ -183,9 +186,9 @@ class LIFUInterface:
             int: The device status.
         """
         if self._test_mode:
-            return STATUS_READY
+            return LIFUInterfaceStatus.STATUS_READY
 
-        status = STATUS_ERROR
+        status = LIFUInterfaceStatus.STATUS_ERROR
         return status
 
     def stop_sonication(self) -> bool:

--- a/src/openlifu/io/__init__.py
+++ b/src/openlifu/io/__init__.py
@@ -1,5 +1,6 @@
-from openlifu.io.LIFUInterface import LIFUInterface
+from openlifu.io.LIFUInterface import LIFUInterface, LIFUInterfaceStatus
 
 __all__ = [
     "LIFUInterface",
+    "LIFUInterfaceStatus",
 ]

--- a/tests/test_sonication_control_mock.py
+++ b/tests/test_sonication_control_mock.py
@@ -3,7 +3,7 @@ import pytest
 
 from openlifu.bf import Pulse, Sequence
 from openlifu.geo import Point
-from openlifu.io.LIFUInterface import STATUS_READY, LIFUInterface
+from openlifu.io.LIFUInterface import LIFUInterface, LIFUInterfaceStatus
 from openlifu.plan.solution import Solution
 
 
@@ -36,5 +36,5 @@ def test_lifuinterface_mock(example_solution:Solution):
     lifu_interface.set_solution(example_solution)
     lifu_interface.start_sonication()
     status = lifu_interface.get_status()
-    assert status == STATUS_READY
+    assert status == LIFUInterfaceStatus.STATUS_READY
     lifu_interface.stop_sonication()


### PR DESCRIPTION
Leaves #228 open, but works toward it by accomplishing it for `LIFUInterface.py`