### PR TITLE
Add photocollection concept to database (#234)

### DIFF
--- a/db_dvc.dvc
+++ b/db_dvc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: cf89344a4eee1e75c5be53d91941815e.dir
-  size: 803480549
-  nfiles: 83
+- md5: 77217cb7a18172e6db4f130b4931c899.dir
+  size: 829348265
+  nfiles: 249
   hash: md5
   path: db_dvc


### PR DESCRIPTION
Closes #234 

This is necessary for downstream work of generating a photoscan/mesh from the 70-80 photos from 3D Open Water. The 3D Open Water app **does not** generate a mesh, it just takes photos. So we store the photos for downstream analysis.

## In detail

Adds a concept of photocollections to the database. Photocollections are associated with the specific session_id of a specific subject_id, and they are identified by the reference_number. 'reference_number' was used instead of photocollection_id for consistency with 3D Open Water. 3D Open Water takes a collection of `.jpeg` photos and the goal of photocollections are to store that collection of photos into the database for downstream processing; specifically, the plan is for a photocollection of 70-80 photos of a patient's head to be used to create a mesh via an algorithm (i.e. a "photoscan" object). There is no special object associated with a photocollection -- it's just a collection of photos stored in a directory and identified by the reference_number.

## For review

This code is not unit tested but is pretty independent within the subject/session tree. Errors will likely be caught in its usage. Other than reading the code, you could pipe it through an LLM and see if you rolled the right RNG for it to discover a bug.