### PR TITLE
Update DVC solution intensity variable naming

### DIFF
--- a/db_dvc.dvc
+++ b/db_dvc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 77217cb7a18172e6db4f130b4931c899.dir
-  size: 829348265
+- md5: 94e315be828696cd0538ae682294a194.dir
+  size: 829348310
   nfiles: 249
   hash: md5
   path: db_dvc


### PR DESCRIPTION
The issue is described in https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/206 This change should have been made in 261b1011ebea8472fe4072af1fcba1f589c35b03 while working on #105.

I ran the "standardize dvc data" script as well so that also changed a few trivial things like adding time stamps, rearranging some json lines, etc.

For reference here is the script that I used to do the rename:

```py
import pathlib
from openlifu.db import Database
from openlifu.db.database import OnConflictOpts

db = Database("db_dvc/")

for subject_id in db.get_subject_ids():
    for session_id in db.get_session_ids(subject_id):
        session = db.load_session(db.load_subject(subject_id), session_id)
        for solution_id in db.get_solution_ids(subject_id, session_id):
            solution = db.load_solution(session, solution_id)
            solution.simulation_result = solution.simulation_result.rename({"ita":"intensity"})
            db.write_solution(session, solution, on_conflict=OnConflictOpts.OVERWRITE)
            print(f"Applied variable rename to solution {solution.id}.")
```