### PR TITLE
Add user roles to individual protocols

### DIFF
--- a/src/openlifu/plan/protocol.py
+++ b/src/openlifu/plan/protocol.py
@@ -41,6 +41,9 @@ class Protocol:
     description: Annotated[str, OpenLIFUFieldData("Protocol description", "A more detailed description of the protocol")] = ""
     """A more detailed description of the protocol"""
 
+    allowed_roles: Annotated[List[str], OpenLIFUFieldData("Allowed roles", "A list of user roles allowed to interact with this protocol")] = field(default_factory=list)
+    """A list of user roles allowed to interact with this protocol"""
+
     pulse: Annotated[bf.Pulse, OpenLIFUFieldData("Pulse definition", "The pulse definition used in the protocol")] = field(default_factory=bf.Pulse)
     """The pulse definition used in the protocol"""
 


### PR DESCRIPTION
Closes #239 

Adds a field to the protocol class that holds a list of roles, so that individual protocols can be designated for use by specific groups.

- [x] TODO: Once this is done, we can open an issue on SlicerOpenLIFU to work on enforcing the user role when in "user account mode". Enforcing it could mean anything and is up to the application, but one idea is, whenever showing protocols to choose from, to simply filter out and not show any protocols that have this user role attribute and for which the currently logged in user does not match. Something would also have to be done for loading protocols from file.