### PR TITLE
Serialize allowed-roles in `Protocol.to_dict` (#294)

### DIFF
--- a/db_dvc.dvc
+++ b/db_dvc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: b5d5ad14d93e38f9600fea910603e6d6.dir
+- md5: bf109e310734c61c0eecff737562b425.dir
   nfiles: 257
   hash: md5
   path: db_dvc
-  size: 933880436
+  size: 933880511

--- a/src/openlifu/plan/param_constraint.py
+++ b/src/openlifu/plan/param_constraint.py
@@ -8,7 +8,7 @@ from openlifu.util.dict_conversion import DictMixin
 
 PARAM_STATUS_SYMBOLS = {
     "ok": "✅",
-    "warning": "⚠️",
+    "warning": "❗",
     "error": "❌"
 }
 

--- a/src/openlifu/plan/param_constraint.py
+++ b/src/openlifu/plan/param_constraint.py
@@ -26,12 +26,12 @@ class ParameterConstraint(DictMixin):
     def __post_init__(self):
         if self.warning_value is None and self.error_value is None:
             raise ValueError("At least one of warning_value or error_value must be set")
-        if self.operator in ['within','inside','outside','outside_inclusive']:
-            if self.warning_value and (not isinstance(self.warning_value, tuple) or len(self.warning_value) != 2 or (self.warning_value[0] >= self.warning_value[1])):
+        if self.operator in ['within', 'inside', 'outside', 'outside_inclusive']:
+            if self.warning_value and (not isinstance(self.warning_value, tuple) or len(self.warning_value) != 2 or self.warning_value[0] >= self.warning_value[1]):
                 raise ValueError("Warning value must be a sorted tuple of two numbers")
-            if self.error_value and (not isinstance(self.error_value, tuple) or len(self.error_value) != 2 or not (self.error_value[0] >= self.error_value[1])):
+            if self.error_value and (not isinstance(self.error_value, tuple) or len(self.error_value) != 2 or self.error_value[0] >= self.error_value[1]):
                 raise ValueError("Error value must be a sorted tuple of two numbers")
-        elif self.operator in ['<','<=','>','>=']:
+        elif self.operator in ['<', '<=', '>', '>=']:
             if self.warning_value is not None and not isinstance(self.warning_value, (int, float)):
                 raise ValueError("Warning value must be a single value")
             if self.error_value is not None and not isinstance(self.error_value, (int, float)):

--- a/src/openlifu/plan/protocol.py
+++ b/src/openlifu/plan/protocol.py
@@ -108,6 +108,7 @@ class Protocol:
             "id": self.id,
             "name": self.name,
             "description": self.description,
+            "allowed_roles": self.allowed_roles,
             "pulse": self.pulse.to_dict(),
             "sequence": self.sequence.to_dict(),
             "focal_pattern": self.focal_pattern.to_dict(),

--- a/src/openlifu/plan/protocol.py
+++ b/src/openlifu/plan/protocol.py
@@ -97,10 +97,7 @@ class Protocol:
             d['target_constraints'] = [TargetConstraints.from_dict(d_tc) for d_tc in d.get("target_constraints", {})]
         if "virtual_fit_options" in d:
             d['virtual_fit_options'] = VirtualFitOptions.from_dict(d['virtual_fit_options'])
-        if "analysis_options" in d:
-            if "mainlobe_aspect_ratio" in d["analysis_options"]:
-                d["analysis_options"]["mainlobe_aspect_ratio"] = tuple(d["analysis_options"]["mainlobe_aspect_ratio"])
-            d['analysis_options'] = SolutionAnalysisOptions.from_dict(d.get("analysis_options"))
+        d["analysis_options"] = SolutionAnalysisOptions.from_dict(d.get("analysis_options", {}))
         return Protocol(**d)
 
     def to_dict(self):
@@ -119,7 +116,7 @@ class Protocol:
             "param_constraints": {id: pc.to_dict() for id, pc in self.param_constraints.items()},
             "target_constraints": self.target_constraints,
             "virtual_fit_options": self.virtual_fit_options.to_dict(),
-            "analysis_options": self.analysis_options,
+            "analysis_options": self.analysis_options.to_dict(),
         }
 
     @staticmethod

--- a/tests/resources/example_db/protocols/example_protocol/example_protocol.json
+++ b/tests/resources/example_db/protocols/example_protocol/example_protocol.json
@@ -2,6 +2,7 @@
   "id": "example_protocol",
   "name": "Example protocol",
   "description": "Example protocol created 30-Jan-2024 09:16:02",
+  "allowed_roles": ["operator"],
   "pulse": {
     "frequency": 500000,
     "amplitude": 1,

--- a/tests/test_param_constraints.py
+++ b/tests/test_param_constraints.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from openlifu.plan.param_constraint import ParameterConstraint
+
+# ---- Tests for ParameterConstraint ----
+
+@pytest.fixture()
+def threshold_constraint():
+    return ParameterConstraint(operator="<=", warning_value=5.0, error_value=7.0)
+
+@pytest.fixture()
+def range_constraint():
+    return ParameterConstraint(operator="within", warning_value=(2.0, 4.0), error_value=(1.0, 5.0))
+
+def test_invalid_no_thresholds():
+    with pytest.raises(ValueError, match="At least one of warning_value or error_value must be set"):
+        ParameterConstraint(operator="<=")
+
+def test_invalid_warning_tuple_order():
+    with pytest.raises(ValueError, match="Warning value must be a sorted tuple"):
+        ParameterConstraint(operator="within", warning_value=(4.0, 2.0))
+
+def test_invalid_error_type():
+    with pytest.raises(ValueError, match="Error value must be a single value"):
+        ParameterConstraint(operator=">", error_value=(1.0, 2.0))
+
+@pytest.mark.parametrize(("value", "op", "threshold", "expected"), [
+    (3, "<", 5, True),
+    (5, "<", 5, False),
+    (5, "<=", 5, True),
+    (6, ">", 5, True),
+    (5, ">=", 5, True),
+    (3, "within", (2, 4), True),
+    (2, "within", (2, 4), False),
+    (1, "inside", (2, 4), False),
+    (2, "inside", (2, 4), True),
+    (3, "inside", (2, 4), True),
+    (1, "outside", (2, 4), True),
+    (2, "outside", (2, 4), False),
+    (2, "outside_inclusive", (2, 4), True),
+    (3, "outside_inclusive", (2, 4), False),
+])
+def test_compare(value, op, threshold, expected):
+    assert ParameterConstraint.compare(value, op, threshold) == expected
+
+def test_is_warning(threshold_constraint):
+    assert not threshold_constraint.is_warning(4.0)
+    assert threshold_constraint.is_warning(6.0)
+
+def test_is_error(threshold_constraint):
+    assert not threshold_constraint.is_error(6.0)
+    assert threshold_constraint.is_error(8.0)
+
+def test_is_warning_range(range_constraint):
+    assert not range_constraint.is_warning(3.0)
+    assert range_constraint.is_warning(4.5)
+
+def test_is_error_range(range_constraint):
+    assert not range_constraint.is_error(3.0)
+    assert range_constraint.is_error(5.5)
+
+@pytest.mark.parametrize(("value", "expected_status"), [
+    (3.0, "ok"),
+    (6.5, "warning"),
+    (7.5, "error"),
+])
+def test_get_status_threshold(value, expected_status):
+    constraint = ParameterConstraint(operator="<=", warning_value=5.5, error_value=7.0)
+    assert constraint.get_status(value) == expected_status
+
+@pytest.mark.parametrize(("value", "expected"), [
+    (2.5, "ok"),
+    (0.5, "warning"),
+    (5.5, "error"),
+])
+def test_get_status_range(value, expected):
+    constraint = ParameterConstraint(operator="within", warning_value=(1.0, 4.0), error_value=(0.0, 5.0))
+    assert constraint.get_status(value) == expected

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -31,6 +31,11 @@ def example_session() -> Session:
 def example_wheel_pattern() -> Wheel:
     return Wheel(num_spokes=6)
 
+def test_to_dict_from_dict(example_protocol: Protocol):
+    proto_dict = example_protocol.to_dict()
+    new_protocol = Protocol.from_dict(proto_dict)
+    assert new_protocol == example_protocol
+
 @pytest.mark.parametrize("compact_representation", [True, False])
 def test_serialize_deserialize_protocol(example_protocol : Protocol, compact_representation: bool):
     assert example_protocol.from_json(example_protocol.to_json(compact_representation)) == example_protocol

--- a/tests/test_solution_analysis.py
+++ b/tests/test_solution_analysis.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from openlifu.plan.param_constraint import ParameterConstraint
+from openlifu.plan.solution_analysis import SolutionAnalysis, SolutionAnalysisOptions
+
+# ---- Tests for SolutionAnalysis ----
+
+@pytest.fixture()
+def example_solution_analysis() -> SolutionAnalysis:
+    return SolutionAnalysis(
+        mainlobe_pnp_MPa=[1.1, 1.2],
+        mainlobe_isppa_Wcm2=[10.0, 12.0],
+        mainlobe_ispta_mWcm2=[500.0, 520.0],
+        beamwidth_lat_3dB_mm=[1.5, 1.6],
+        beamwidth_ele_3dB_mm=[2.0, 2.1],
+        beamwidth_ax_3dB_mm=[3.0, 3.1],
+        beamwidth_lat_6dB_mm=[1.8, 1.9],
+        beamwidth_ele_6dB_mm=[2.5, 2.6],
+        beamwidth_ax_6dB_mm=[3.5, 3.6],
+        sidelobe_pnp_MPa=[0.5, 0.6],
+        sidelobe_isppa_Wcm2=[5.0, 5.5],
+        global_pnp_MPa=[1.3],
+        global_isppa_Wcm2=[13.0],
+        p0_MPa=[1.0, 1.1],
+        TIC=0.7,
+        power_W=25.0,
+        MI=1.2,
+        global_ispta_mWcm2=540.0,
+        param_constraints={
+            "global_pnp_MPa": ParameterConstraint(
+                operator="<=",
+                warning_value=1.4,
+                error_value=1.6
+            )
+        }
+    )
+
+def test_to_dict_from_dict_solution_analysis(example_solution_analysis: SolutionAnalysis):
+    sa_dict = example_solution_analysis.to_dict()
+    new_solution = SolutionAnalysis.from_dict(sa_dict)
+    assert new_solution == example_solution_analysis
+
+@pytest.mark.parametrize("compact", [True, False])
+def test_serialize_deserialize_solution_analysis(example_solution_analysis: SolutionAnalysis, compact: bool):
+    json_str = example_solution_analysis.to_json(compact)
+    deserialized = SolutionAnalysis.from_json(json_str)
+    assert deserialized == example_solution_analysis
+
+
+# ---- Tests for SolutionAnalysisOptions ----
+
+
+@pytest.fixture()
+def example_solution_analysis_options() -> SolutionAnalysisOptions:
+    return SolutionAnalysisOptions(
+        standoff_sound_speed=1480.0,
+        standoff_density=990.0,
+        ref_sound_speed=1540.0,
+        ref_density=1020.0,
+        mainlobe_aspect_ratio=(1.0, 1.0, 4.0),
+        mainlobe_radius=2.0e-3,
+        beamwidth_radius=4.0e-3,
+        sidelobe_radius=2.5e-3,
+        sidelobe_zmin=0.5e-3,
+        distance_units="mm",
+        param_constraints={
+            "mainlobe_radius": ParameterConstraint(
+                operator=">=",
+                warning_value=1.5e-3,
+                error_value=1.0e-3
+            )
+        }
+    )
+
+def test_to_dict_from_dict_solution_analysis_options(example_solution_analysis_options: SolutionAnalysisOptions):
+    options_dict = example_solution_analysis_options.to_dict()
+    new_options = SolutionAnalysisOptions.from_dict(options_dict)
+    assert new_options == example_solution_analysis_options


### PR DESCRIPTION
Closes #294 
Closes #296 
Closes #298
Contributes to #297 

- Fixes a small issue where allowed_roles could not be serialized.
- Also update db_dvc after running the script in `scripts/standardize_database.py`, which now shows the serialized `Protocol.allowed_roles`
- Fixes an issue where SolutionAnalysis and SolutionAnalysisOptions were not serialized correctly. It does this by introducing failing tests and fixing them.
- Fixes an issue where `ParameterConstraint` had an incorrect `__post_init__` (and adds tests)

## For review

Check the code is good enough. I checked out this branch in the extension and was able to fully interact with Protocols without issues (saving and loading).  Furthermore, after using this branch, the error in [SlicerOpenLIFU#284](https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/284) regarding the ParameterConstraint objects being swapped for dictionaries went away.