### PR TITLE
VF debugging info and progress callbacks, and mesh recon progress callbacks

### DIFF
--- a/src/openlifu/virtual_fit.py
+++ b/src/openlifu/virtual_fit.py
@@ -379,7 +379,7 @@ def virtual_fit(
     if include_debug_info:
         log.info("Generating debug meshes...")
         progress_callback(80, "Generating debug meshes")
-        interpolator_mesh : vtk.vtkPolyData = sphere_from_interpolator(skin_interpolator)
+        interpolator_mesh : vtk.vtkPolyData = sphere_from_interpolator(skin_interpolator, theta_res=100, phi_res=100)
 
         # A few things are in ASL coordinates, so we transform it to RAS space so that they are in the same coordinates as skin_mesh.
         interpolator_mesh = apply_affine_to_polydata(interpolator2ras, interpolator_mesh)


### PR DESCRIPTION
- Splits out skin mesh computation from virtual fit function to its own function `compute_skin_mesh_from_volume`. Allow skin mesh to optionally be . This is what @sadhana-r had already done (before my interruption :grin:), and is needed for [SlicerOpenLIFU#195](https://github.com/OpenwaterHealth/SlicerOpenLIFU/issues/195).
- Adds an option to return a packet of debugging info `VirtualFitDebugInfo`.
- Adds an option to include a progress callback in both the virtual fitting and the mesh reconstruction.

# For Review

- A cursory look over the code is sufficient. Each commit does something quite different so it will be easier to look at the commits one by one. The only one to look at carefully is the first commit, the one that splits out the skin mesh computation, since you will immediately need to use that.
- The easiest way to review functionality is to try out the companion SlicerOpenLIFU PR: https://github.com/OpenwaterHealth/SlicerOpenLIFU/pull/381