### PR TITLE
Fix #134: Prevent duplicate target IDs in Session

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from openlifu.db.session import Session
+from openlifu.geo import Point
+
+
+def test_duplicate_target_ids_raises():
+    target1 = Point(id="T1", position=[0, 0, 0])
+    target2 = Point(id="T1", position=[1, 1, 1])  # Duplicate ID
+
+    with pytest.raises(ValueError, match="Duplicate target IDs found"):
+        Session(targets=[target1, target2])


### PR DESCRIPTION

This pull request fixes issue [[#134](https://github.com/OpenwaterHealth/OpenLIFU-python/issues/134)](https://github.com/OpenwaterHealth/OpenLIFU-python/issues/134) by adding a check in the `Session` class to prevent duplicate target IDs.

### 🔧 Changes Made

* Added a validation step in `Session.__post_init__` to ensure all target IDs are unique.
* Added a test case in `test_session.py` to verify the behavior.
* Passed all pre-commit checks and linters (`pre-commit`, `ruff`, etc.).

### ✅ Why This Matters

Ensuring unique target IDs helps prevent data integrity issues and logic bugs during session processing.

Let me know if any changes or refactors are needed.