### PR TITLE
302 add more strict post init checks across codebase

### DIFF
--- a/src/openlifu/bf/apod_methods/maxangle.py
+++ b/src/openlifu/bf/apod_methods/maxangle.py
@@ -9,6 +9,7 @@ import xarray as xa
 from openlifu.bf.apod_methods import ApodizationMethod
 from openlifu.geo import Point
 from openlifu.util.annotations import OpenLIFUFieldData
+from openlifu.util.units import getunittype
 from openlifu.xdc import Transducer
 
 
@@ -19,6 +20,15 @@ class MaxAngle(ApodizationMethod):
 
     units: Annotated[str, OpenLIFUFieldData("Angle units", "Angle units")] = "deg"
     """Angle units"""
+
+    def __post_init__(self):
+        if not isinstance(self.max_angle, (int, float)):
+            raise TypeError(f"Max angle must be a number, got {type(self.max_angle).__name__}.")
+        if self.max_angle < 0:
+            raise ValueError(f"Max angle must be non-negative, got {self.max_angle}.")
+        if getunittype(self.units) != "angle":
+            raise ValueError(f"Units must be an angle type, got {self.units}.")
+        super().__post_init__()
 
     def calc_apodization(self, arr: Transducer, target: Point, params: xa.Dataset, transform:np.ndarray | None=None):
         target_pos = target.get_position(units="m")

--- a/src/openlifu/bf/delay_methods/direct.py
+++ b/src/openlifu/bf/delay_methods/direct.py
@@ -17,6 +17,13 @@ class Direct(DelayMethod):
     c0: Annotated[float, OpenLIFUFieldData("Speed of Sound (m/s)", "Speed of sound in the medium (m/s)")] = 1480.0
     """Speed of sound in the medium (m/s)"""
 
+    def __post_init__(self):
+        if self.c0 <= 0:
+            raise ValueError("Speed of sound must be greater than 0")
+        if not isinstance(self.c0, (int, float)):
+            raise TypeError("Speed of sound must be a number")
+        self.c0 = float(self.c0)
+
     def calc_delays(self, arr: Transducer, target: Point, params: xa.Dataset | None=None, transform:np.ndarray | None=None):
         if params is None:
             c = self.c0

--- a/src/openlifu/bf/delay_methods/direct.py
+++ b/src/openlifu/bf/delay_methods/direct.py
@@ -18,10 +18,10 @@ class Direct(DelayMethod):
     """Speed of sound in the medium (m/s)"""
 
     def __post_init__(self):
-        if self.c0 <= 0:
-            raise ValueError("Speed of sound must be greater than 0")
         if not isinstance(self.c0, (int, float)):
             raise TypeError("Speed of sound must be a number")
+        if self.c0 <= 0:
+            raise ValueError("Speed of sound must be greater than 0")
         self.c0 = float(self.c0)
 
     def calc_delays(self, arr: Transducer, target: Point, params: xa.Dataset | None=None, transform:np.ndarray | None=None):

--- a/src/openlifu/bf/focal_patterns/focal_pattern.py
+++ b/src/openlifu/bf/focal_patterns/focal_pattern.py
@@ -7,6 +7,7 @@ from typing import Annotated
 from openlifu.bf import focal_patterns
 from openlifu.geo import Point
 from openlifu.util.annotations import OpenLIFUFieldData
+from openlifu.util.units import getunittype
 
 
 @dataclass
@@ -20,6 +21,14 @@ class FocalPattern(ABC):
 
     units: Annotated[str, OpenLIFUFieldData("Pressure units", "Pressure units")] = "Pa"
     """Pressure units"""
+
+    def __post_init__(self):
+        if self.target_pressure <= 0:
+            raise ValueError("Target pressure must be greater than 0")
+        if not isinstance(self.units, str):
+            raise TypeError("Units must be a string")
+        if getunittype(self.units) != 'pressure':
+            raise ValueError(f"Units must be a pressure unit, got {self.units}")
 
     @abstractmethod
     def get_targets(self, target: Point):

--- a/src/openlifu/bf/focal_patterns/wheel.py
+++ b/src/openlifu/bf/focal_patterns/wheel.py
@@ -28,6 +28,15 @@ class Wheel(FocalPattern):
     distance_units: Annotated[str, OpenLIFUFieldData("Units", "Units of the wheel pattern parameters")] = "mm"
     """Units of the wheel pattern parameters"""
 
+    def __post_init__(self):
+        if not isinstance(self.center, bool):
+            raise TypeError(f"Center must be a boolean, got {type(self.center).__name__}.")
+        if not isinstance(self.num_spokes, int) or self.num_spokes < 1:
+            raise ValueError(f"Number of spokes must be a positive integer, got {self.num_spokes}.")
+        if not isinstance(self.spoke_radius, (int, float)) or self.spoke_radius <= 0:
+            raise ValueError(f"Spoke radius must be a positive number, got {self.spoke_radius}.")
+        super().__post_init__()
+
     def get_targets(self, target: Point):
         """
         Get the targets of the focal pattern

--- a/src/openlifu/bf/pulse.py
+++ b/src/openlifu/bf/pulse.py
@@ -25,6 +25,14 @@ class Pulse(DictMixin):
     duration: Annotated[float, OpenLIFUFieldData("Duration (s)", "Duration of the pulse in s")] = 1.0  # s
     """Duration of the pulse in s"""
 
+    def __post_init__(self):
+        if self.frequency <= 0:
+            raise ValueError("Frequency must be greater than 0")
+        if self.amplitude < 0 or self.amplitude > 1:
+            raise ValueError("Amplitude must be between 0 and 1")
+        if self.duration <= 0:
+            raise ValueError("Duration must be greater than 0")
+
     def calc_pulse(self, t: np.array):
         """
         Calculate the pulse at the given times

--- a/src/openlifu/bf/sequence.py
+++ b/src/openlifu/bf/sequence.py
@@ -52,3 +52,23 @@ class Sequence(DictMixin):
             {"Name": "Pulse Train Count", "Value": self.pulse_train_count, "Unit": ""}
         ]
         return pd.DataFrame.from_records(records)
+
+    def get_pulse_train_duration(self) -> float:
+        """
+        Get the duration of a single pulse train in seconds
+
+        :returns: Duration of a single pulse train in seconds
+        """
+        return self.pulse_interval * self.pulse_count
+
+    def get_sequence_duration(self) -> float:
+        """
+        Get the total duration of the sequence in seconds
+
+        :returns: Total duration of the sequence in seconds
+        """
+        if self.pulse_train_interval == 0:
+            interval = self.get_pulsetrain_duration()
+        else:
+            interval = self.pulse_train_interval
+        return interval * self.pulse_train_count

--- a/src/openlifu/plan/solution.py
+++ b/src/openlifu/plan/solution.py
@@ -95,6 +95,37 @@ class Solution:
     """Approval state of this solution as a sonication plan. `True` means the user has provided some
     kind of confirmation that the solution is safe and acceptable to be executed."""
 
+    def __post_init__(self):
+        if self.delays is not None:
+            self.delays = np.array(self.delays, ndmin=2)
+        if self.apodizations is not None:
+            self.apodizations = np.array(self.apodizations, ndmin=2)
+
+        if self.pulse.frequency <= 0:
+            raise ValueError("Pulse frequency must be positive")
+        if self.voltage <= 0:
+            raise ValueError("Voltage must be positive")
+        if self.sequence.pulse_interval <= 0:
+            raise ValueError("Pulse interval must be positive")
+        if self.sequence.pulse_count <= 0:
+            raise ValueError("Pulse count must be positive")
+        if self.sequence.pulse_train_interval < 0:
+            raise ValueError("Pulse train interval must be non-negative")
+        elif (self.sequence.pulse_train_interval > 0) and (self.sequence.pulse_train_interval < (self.sequence.pulse_interval * self.sequence.pulse_count)):
+            raise ValueError("Pulse train interval must be greater than or equal to the total pulse interval")
+        if self.sequence.pulse_train_count <= 0:
+            raise ValueError("Pulse train count must be positive")
+        if len(self.foci)>0 and self.delays is not None and self.delays.shape[0] != len(self.foci):
+                raise ValueError(f"Delays number of foci ({self.delays.shape[0]}) does not match number of foci ({len(self.foci)})")
+        if len(self.foci)>0 and self.apodizations is not None and self.apodizations.shape[0] != len(self.foci):
+                raise ValueError(f"Apodizations number of foci ({self.apodizations.shape[0]}) does not match number of foci ({len(self.foci)})")
+        if self.delays is not None and self.apodizations is not None:
+            if self.apodizations.shape[0] != self.delays.shape[0]:
+                raise ValueError(f"Apodizations number of foci ({self.apodizations.shape[0]}) does not match delays number of foci ({self.delays.shape[0]})")
+            if self.apodizations.shape[1] != self.delays.shape[1]:
+                raise ValueError(f"Apodizations number of elements {self.apodizations.shape[1]} does not match delays shape ({self.delays.shape[1]})")
+
+
     def num_foci(self) -> int:
         """Get the number of foci"""
         return len(self.foci)

--- a/src/openlifu/plan/solution_analysis.py
+++ b/src/openlifu/plan/solution_analysis.py
@@ -11,6 +11,7 @@ import xarray as xa
 from openlifu.plan.param_constraint import PARAM_STATUS_SYMBOLS, ParameterConstraint
 from openlifu.util.annotations import OpenLIFUFieldData
 from openlifu.util.dict_conversion import DictMixin
+from openlifu.util.units import getunittype
 
 DEFAULT_ORIGIN = np.zeros(3)
 
@@ -213,6 +214,32 @@ class SolutionAnalysisOptions(DictMixin):
 
     param_constraints: Annotated[Dict[str, ParameterConstraint], OpenLIFUFieldData("Parameter constraints", None)] = field(default_factory=dict)
     """TODO: Add description"""
+
+    def __post_init__(self):
+        if self.standoff_sound_speed <= 0:
+            raise ValueError("Standoff sound speed must be greater than 0")
+        if self.standoff_density <= 0:
+            raise ValueError("Standoff density must be greater than 0")
+        if self.ref_sound_speed <= 0:
+            raise ValueError("Reference sound speed must be greater than 0")
+        if self.ref_density <= 0:
+            raise ValueError("Reference density must be greater than 0")
+        if not isinstance(self.mainlobe_aspect_ratio, tuple) or len(self.mainlobe_aspect_ratio) != 3:
+            raise TypeError("Mainlobe aspect ratio must be a tuple of three floats (lat, ele, ax)")
+        if not all(isinstance(x, (int, float)) for x in self.mainlobe_aspect_ratio):
+            raise TypeError("Mainlobe aspect ratio must contain only numbers")
+        if not isinstance(self.mainlobe_radius, (int, float)) or self.mainlobe_radius <= 0:
+            raise ValueError("Mainlobe radius must be a positive number")
+        if not isinstance(self.beamwidth_radius, (int, float)) or self.beamwidth_radius <= 0:
+            raise ValueError("Beamwidth radius must be a positive number")
+        if not isinstance(self.sidelobe_radius, (int, float)) or self.sidelobe_radius <= 0:
+            raise ValueError("Sidelobe radius must be a positive number")
+        if not isinstance(self.sidelobe_zmin, (int, float)) or self.sidelobe_zmin < 0:
+            raise ValueError("Sidelobe minimum z must be a non-negative number")
+        if not isinstance(self.distance_units, str):
+            raise TypeError("Distance units must be a string")
+        if getunittype(self.distance_units) != 'distance':
+            raise ValueError(f"Distance units must be a length unit, got {self.distance_units}")
 
     @classmethod
     def from_dict(cls: Type[SolutionAnalysisOptions], parameter_dict: Dict[str, Any]) -> SolutionAnalysisOptions:

--- a/src/openlifu/plan/solution_analysis.py
+++ b/src/openlifu/plan/solution_analysis.py
@@ -224,8 +224,9 @@ class SolutionAnalysisOptions(DictMixin):
             raise ValueError("Reference sound speed must be greater than 0")
         if self.ref_density <= 0:
             raise ValueError("Reference density must be greater than 0")
-        if not isinstance(self.mainlobe_aspect_ratio, tuple) or len(self.mainlobe_aspect_ratio) != 3:
-            raise TypeError("Mainlobe aspect ratio must be a tuple of three floats (lat, ele, ax)")
+        if not isinstance(self.mainlobe_aspect_ratio, (tuple, list)) or len(self.mainlobe_aspect_ratio) != 3:
+            raise TypeError("Mainlobe aspect ratio must be a tuple or list of three floats (lat, ele, ax)")
+        self.mainlobe_aspect_ratio = tuple(self.mainlobe_aspect_ratio)  # Ensure it's a tuple
         if not all(isinstance(x, (int, float)) for x in self.mainlobe_aspect_ratio):
             raise TypeError("Mainlobe aspect ratio must contain only numbers")
         if not isinstance(self.mainlobe_radius, (int, float)) or self.mainlobe_radius <= 0:
@@ -250,8 +251,6 @@ class SolutionAnalysisOptions(DictMixin):
             parameter_dict: dictionary of parameters to define the object
         Returns: new object
         """
-        parameter_dict["mainlobe_aspect_ratio"] = tuple(parameter_dict["mainlobe_aspect_ratio"]) \
-            if isinstance(parameter_dict.get("mainlobe_aspect_ratio"), list) else parameter_dict.get("mainlobe_aspect_ratio")
         parameter_dict["param_constraints"] = {
             k: ParameterConstraint.from_dict(v)
             for k, v in parameter_dict.get("param_constraints", {}).items()

--- a/src/openlifu/plan/target_constraints.py
+++ b/src/openlifu/plan/target_constraints.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 from openlifu.util.annotations import OpenLIFUFieldData
 from openlifu.util.dict_conversion import DictMixin
+from openlifu.util.units import getunittype
 
 
 @dataclass
@@ -32,6 +33,22 @@ class TargetConstraints(DictMixin):
 
     max: Annotated[float, OpenLIFUFieldData("Maximum allowed value", "The maximum value of the dimension")] = float("inf")
     """The maximum value of the dimension"""
+
+    def __post_init__(self):
+        if not isinstance(self.dim, str):
+            raise TypeError("Dimension ID must be a string")
+        if not isinstance(self.name, str):
+            raise TypeError("Dimension name must be a string")
+        if not isinstance(self.units, str):
+            raise TypeError("Dimension units must be a string")
+        if getunittype(self.units) != 'distance':
+            raise ValueError(f"Units must be a length unit, got {self.units}")
+        if not isinstance(self.min, (int, float)):
+            raise TypeError("Minimum value must be a number")
+        if not isinstance(self.max, (int, float)):
+            raise TypeError("Maximum value must be a number")
+        if self.min > self.max:
+            raise ValueError("Minimum value cannot be greater than maximum value")
 
     def check_bounds(self, pos: float):
         """Check if the given position is within bounds."""

--- a/src/openlifu/seg/material.py
+++ b/src/openlifu/seg/material.py
@@ -40,6 +40,30 @@ class Material:
     thermal_conductivity: Annotated[float, OpenLIFUFieldData("Thermal conductivity (W/m/K)", "Thermal conductivity of the material (W/m/K)")] = 0.598  # W/m/K
     """Thermal conductivity of the material (W/m/K)"""
 
+    def __post_init__(self):
+        if not isinstance(self.name, str):
+            raise TypeError("Material name must be a string.")
+        if not isinstance(self.sound_speed, (int, float)):
+            raise TypeError(f"Sound speed of {self.name} must be a number.")
+        if self.sound_speed <= 0:
+            raise ValueError(f"Sound speed of {self.name} must be positive.")
+        if not isinstance(self.density, (int, float)):
+            raise TypeError(f"Density of {self.name} must be a number.")
+        if self.density <= 0:
+            raise ValueError(f"Density of {self.name} must be positive.")
+        if not isinstance(self.attenuation, (int, float)):
+            raise TypeError(f"Attenuation of {self.name} must be a number.")
+        if self.attenuation < 0:
+            raise ValueError(f"Attenuation of {self.name} must be non-negative.")
+        if not isinstance(self.specific_heat, (int, float)):
+            raise TypeError(f"Specific heat of {self.name} must be a number.")
+        if self.specific_heat <= 0:
+            raise ValueError(f"Specific heat of {self.name} must be positive.")
+        if not isinstance(self.thermal_conductivity, (int, float)):
+            raise TypeError(f"Thermal conductivity of {self.name} must be a number.")
+        if self.thermal_conductivity <= 0:
+            raise ValueError(f"Thermal conductivity of {self.name} must be positive.")
+
     def to_dict(self):
         return {
             "name": self.name,

--- a/src/openlifu/seg/seg_method.py
+++ b/src/openlifu/seg/seg_method.py
@@ -23,6 +23,10 @@ class SegmentationMethod(ABC):
     def __post_init__(self):
         if self.materials is None:
             self.materials = MATERIALS.copy()
+        if not isinstance(self.materials, dict):
+            raise TypeError(f"Materials must be a dictionary, got {type(self.materials).__name__}.")
+        if not all(isinstance(m, Material) for m in self.materials.values()):
+            raise TypeError("All materials must be instances of Material class.")
         if self.ref_material not in self.materials:
             raise ValueError(f"Reference material {self.ref_material} not found.")
 

--- a/src/openlifu/sim/sim_setup.py
+++ b/src/openlifu/sim/sim_setup.py
@@ -11,7 +11,7 @@ from openlifu.geo import Point
 from openlifu.seg import SegmentationMethod
 from openlifu.util.annotations import OpenLIFUFieldData
 from openlifu.util.dict_conversion import DictMixin
-from openlifu.util.units import getunitconversion
+from openlifu.util.units import getunitconversion, getunittype
 from openlifu.xdc import Transducer
 
 
@@ -60,10 +60,40 @@ class SimSetup(DictMixin):
             raise ValueError("names must have length 3.")
         if len(self.x_extent) != 2:
             raise ValueError("x_extent must have length 2.")
+        if self.x_extent[0] >= self.x_extent[1]:
+            raise ValueError("x_extent must be in the form (min, max) with min < max.")
         if len(self.y_extent) != 2:
             raise ValueError("y_extent must have length 2.")
+        if self.y_extent[0] >= self.y_extent[1]:
+            raise ValueError("y_extent must be in the form (min, max) with min < max.")
         if len(self.z_extent) != 2:
             raise ValueError("z_extent must have length 2.")
+        if self.z_extent[0] >= self.z_extent[1]:
+            raise ValueError("z_extent must be in the form (min, max) with min < max.")
+        if not isinstance(self.spacing, (int, float)):
+            raise TypeError("spacing must be a number.")
+        if self.spacing <= 0:
+            raise ValueError("spacing must be a positive number.")
+        if not isinstance(self.units, str):
+            raise TypeError("units must be a string.")
+        if getunittype(self.units) != 'distance':
+            raise ValueError(f"units must be a length unit, got {self.units}.")
+        if not isinstance(self.c0, (int, float)):
+            raise TypeError("c0 must be a number.")
+        if self.c0 <= 0:
+            raise ValueError("c0 must be a positive number.")
+        if not isinstance(self.cfl, (int, float)):
+            raise TypeError("cfl must be a number.")
+        if self.cfl <= 0:
+            raise ValueError("cfl must be a positive number.")
+        if not isinstance(self.dt, (int, float)):
+            raise TypeError("dt must be a number.")
+        if self.dt < 0:
+            raise ValueError("dt must be a non-negative number.")
+        if not isinstance(self.t_end, (int, float)):
+            raise TypeError("t_end must be a number.")
+        if self.t_end < 0:
+            raise ValueError("t_end must be a non-negative number.")
         self.dims = tuple(self.dims)
         self.names = tuple(self.names)
         nx = np.diff(self.x_extent)/self.spacing

--- a/src/openlifu/util/units.py
+++ b/src/openlifu/util/units.py
@@ -27,7 +27,7 @@ def getunittype(unit):
     elif unit.endswith('hz'):
         return 'frequency'
     elif unit.endswith('pa'):
-        return 'pascal'
+        return 'pressure'
     elif unit.endswith('w'):
         return 'watt'
     else:
@@ -122,7 +122,7 @@ def getsiscale(unit, type):
     elif type == 'angle':
         idx = len(unit)
 
-    elif type == 'frequency' or type == "pascal":
+    elif type == 'frequency' or type == "pressure":
         idx = len(unit) - 2
 
     elif type == "watt":

--- a/src/openlifu/virtual_fit.py
+++ b/src/openlifu/virtual_fit.py
@@ -31,7 +31,7 @@ from openlifu.seg.skinseg import (
 )
 from openlifu.util.annotations import OpenLIFUFieldData
 from openlifu.util.dict_conversion import DictMixin
-from openlifu.util.units import getunitconversion
+from openlifu.util.units import getunitconversion, getunittype
 
 log = logging.getLogger("VirtualFit")
 
@@ -89,6 +89,52 @@ class VirtualFitOptions(DictMixin):
 
     planefit_dpitch_step: Annotated[float, OpenLIFUFieldData("Plane fit pitch step", "Local pitch axis step size to use when constructing plane fitting grids. In spatial units of `units`")] = 3
     """Local pitch axis step size to use when constructing plane fitting grids. In spatial units of `units`."""
+
+    def __post_init__(self):
+        if not isinstance(self.units, str):
+            raise TypeError("Units must be a string")
+        if getunittype(self.units) != 'distance':
+            raise ValueError(f"Units must be a length unit, got {self.units}")
+        if self.transducer_steering_center_distance <= 0:
+            raise ValueError("Transducer steering center distance must be greater than 0")
+        if not isinstance(self.transducer_steering_center_distance, (int, float)):
+            raise TypeError("Transducer steering center distance must be a number")
+        if not isinstance(self.steering_limits, tuple) or len(self.steering_limits) != 3:
+            raise ValueError("Steering limits must be a tuple of three tuples, each with two elements")
+        if not all(isinstance(sl, tuple) and len(sl) == 2 for sl in self.steering_limits):
+            raise ValueError("Each steering limit must be a tuple of two elements")
+        if not all(isinstance(sl[0], (int, float)) and isinstance(sl[1], (int, float)) for sl in self.steering_limits):
+            raise ValueError("Each steering limit must contain two numbers")
+        if not isinstance(self.pitch_range, tuple) or len(self.pitch_range) != 2:
+            raise ValueError("Pitch range must be a tuple of two elements")
+        if not all(isinstance(pr, (int, float)) for pr in self.pitch_range):
+            raise ValueError("Pitch range must contain two numbers")
+        if not isinstance(self.pitch_step, (int, float)):
+            raise TypeError("Pitch step must be a number")
+        if self.pitch_step <= 0:
+            raise ValueError("Pitch step must be greater than 0")
+        if not isinstance(self.yaw_range, tuple) or len(self.yaw_range) != 2:
+            raise ValueError("Yaw range must be a tuple of two elements")
+        if not all(isinstance(yr, (int, float)) for yr in self.yaw_range):
+            raise ValueError("Yaw range must contain two numbers")
+        if not isinstance(self.yaw_step, (int, float)):
+            raise TypeError("Yaw step must be a number")
+        if self.yaw_step <= 0:
+            raise ValueError("Yaw step must be greater than 0")
+        if not isinstance(self.planefit_dyaw_extent, (int, float)):
+            raise TypeError("Plane fit yaw extent must be a number")
+        if self.planefit_dyaw_extent <= 0:
+            raise ValueError("Plane fit yaw extent must be greater than 0")
+        if not isinstance(self.planefit_dyaw_step, (int, float)):
+            raise TypeError("Plane fit yaw step must be a number")
+        if self.planefit_dyaw_step <= 0:
+            raise ValueError("Plane fit yaw step must be greater than 0")
+        if not isinstance(self.planefit_dpitch_extent, (int, float)):
+            raise TypeError("Plane fit pitch extent must be a number")
+        if self.planefit_dpitch_extent <= 0:
+            raise ValueError("Plane fit pitch extent must be greater than 0")
+        if not isinstance(self.planefit_dpitch_step, (int, float)):
+            raise TypeError("Plane fit pitch step must be a number")
 
     def to_units(self, target_units: str) -> VirtualFitOptions:
         """Do unit conversion and return a version of this VirtualFitOptions that uses


### PR DESCRIPTION
This is an initial set of post_init checks when creating protocols and solutions, and for sending solutions to a `TxInterface`. Final values may get updated when we have better limits on hardware performance or system limitations, but these are a good starting point. The inclusion of the `TxInterface` checks strays a little bit from the original checks (they aren't post_init checks), but it's in the same idea - it just didn't make sense to apply hardware-specific restrictions to the solution itself - those things can be enforced via protocol-specific solution analysis (which knows which hardware it's going to run on), or by other JIT checks that the specific hardware interface can enforce to protect itself.