### PR TITLE
feat: Add mainlobe-to-sidelobe pressure and intensity ratios

### DIFF
--- a/src/openlifu/plan/solution.py
+++ b/src/openlifu/plan/solution.py
@@ -250,8 +250,26 @@ class Solution:
 
             solution_analysis.mainlobe_isppa_Wcm2 += [float(ipa_Wcm2.where(mainlobe_mask).max())]
             solution_analysis.mainlobe_ispta_mWcm2 += [float(ita_mWcm2.where(mainlobe_mask).max())]
-            solution_analysis.sidelobe_pnp_MPa += [float(pnp_MPa.where(sidelobe_mask).max())]
-            solution_analysis.sidelobe_isppa_Wcm2 += [float(ipa_Wcm2.where(sidelobe_mask).max())]
+
+            sidelobe_pnp = float(pnp_MPa.where(sidelobe_mask).max())
+            sidelobe_isppa = float(ipa_Wcm2.where(sidelobe_mask).max())
+
+            solution_analysis.sidelobe_pnp_MPa += [sidelobe_pnp]
+            solution_analysis.sidelobe_isppa_Wcm2 += [sidelobe_isppa]
+
+            # Calculate and store ratios
+            if sidelobe_pnp == 0:
+                pressure_ratio = np.inf if solution_analysis.mainlobe_pnp_MPa[-1] != 0 else np.nan
+            else:
+                pressure_ratio = solution_analysis.mainlobe_pnp_MPa[-1] / sidelobe_pnp
+            solution_analysis.mainlobe_to_sidelobe_pressure_ratio += [pressure_ratio]
+
+            if sidelobe_isppa == 0:
+                intensity_ratio = np.inf if solution_analysis.mainlobe_isppa_Wcm2[-1] != 0 else np.nan
+            else:
+                intensity_ratio = solution_analysis.mainlobe_isppa_Wcm2[-1] / sidelobe_isppa
+            solution_analysis.mainlobe_to_sidelobe_intensity_ratio += [intensity_ratio]
+
             solution_analysis.global_pnp_MPa += [float(pnp_MPa.where(z_mask).max())]
             solution_analysis.global_isppa_Wcm2 += [float(ipa_Wcm2.where(z_mask).max())]
             i0_Wcm2 = (p0_Pa**2 / (2*standoff_Z)) * 1e-4

--- a/src/openlifu/plan/solution_analysis.py
+++ b/src/openlifu/plan/solution_analysis.py
@@ -33,6 +33,8 @@ PARAM_FORMATS = {
     "beamwidth_ax_6dB_mm": ["mean", "0.2f", "mm", "6dB Beamwidth (Axial)"],
     "sidelobe_pnp_MPa": ["max", "0.3f", "MPa", "Sidelobe Peak Negative Pressure"],
     "sidelobe_isppa_Wcm2": ["max", "0.1f", "W/cm^2", "Sidelobe I_SPPA"],
+    "mainlobe_to_sidelobe_pressure_ratio": ["mean", "0.2f", "", "Mainlobe/Sidelobe Pressure Ratio"],
+    "mainlobe_to_sidelobe_intensity_ratio": ["mean", "0.2f", "", "Mainlobe/Sidelobe Intensity Ratio"],
     "global_pnp_MPa": ["max", "0.3f", "MPa", "Global Peak Negative Pressure"],
     "global_isppa_Wcm2": ["max", "0.1f", "W/cm^2", "Global I_SPPA"],
     "global_ispta_mWcm2": [None, "0.1f", "mW/cm^2", "Global I_SPTA"],
@@ -97,6 +99,12 @@ class SolutionAnalysis(DictMixin):
 
     sidelobe_isppa_Wcm2: Annotated[list[float], OpenLIFUFieldData("Sidelobe ISPPA", "Spatial peak pulse average intensity in the sidelobes, in W/cm²")] = field(default_factory=list)
     """Spatial peak pulse average intensity in the sidelobes, in W/cm²"""
+
+    mainlobe_to_sidelobe_pressure_ratio: Annotated[list[float], OpenLIFUFieldData("Mainlobe/Sidelobe Pressure Ratio", "Ratio of mainlobe peak negative pressure to sidelobe peak negative pressure")] = field(default_factory=list)
+    """Ratio of mainlobe peak negative pressure to sidelobe peak negative pressure"""
+
+    mainlobe_to_sidelobe_intensity_ratio: Annotated[list[float], OpenLIFUFieldData("Mainlobe/Sidelobe Intensity Ratio", "Ratio of mainlobe spatial peak pulse average intensity to sidelobe spatial peak pulse average intensity")] = field(default_factory=list)
+    """Ratio of mainlobe spatial peak pulse average intensity to sidelobe spatial peak pulse average intensity"""
 
     global_pnp_MPa: Annotated[list[float], OpenLIFUFieldData("Global PNP", "Maximum peak negative pressure in the entire field, in MPa")] = field(default_factory=list)
     """Maximum peak negative pressure in the entire field, in MPa"""

--- a/tests/test_solution_analysis.py
+++ b/tests/test_solution_analysis.py
@@ -21,6 +21,8 @@ def example_solution_analysis() -> SolutionAnalysis:
         beamwidth_ax_6dB_mm=[3.5, 3.6],
         sidelobe_pnp_MPa=[0.5, 0.6],
         sidelobe_isppa_Wcm2=[5.0, 5.5],
+        mainlobe_to_sidelobe_pressure_ratio=[2.2, 2.0],
+        mainlobe_to_sidelobe_intensity_ratio=[2.0, 2.18],
         global_pnp_MPa=[1.3],
         global_isppa_Wcm2=[13.0],
         p0_MPa=[1.0, 1.1],


### PR DESCRIPTION
Adds the calculation and reporting of mainlobe-to-sidelobe pressure and intensity ratios to the SolutionAnalysis.

- New fields in SolutionAnalysis dataclass.
- PARAM_FORMATS updated for table display.
- Ratio calculation logic added to Solution.analyze(), handling division by zero.
- Tests updated and new tests added for ratio calculations.

Closes #345 