### PR TITLE
feat: Remove special cases from SegmenationMethod.from_dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,7 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "error",
-  "ignore:Unsupported Windows version.*ONNX Runtime supports Windows 10 and above, only.:UserWarning",
-  "ignore:Ignoring unexpected keyword arguments for UniformWater.*:UserWarning",
+  "ignore:Unsupported Windows version.*ONNX Runtime supports Windows 10 and above, only.:UserWarning"
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ xfail_strict = true
 filterwarnings = [
   "error",
   "ignore:Unsupported Windows version.*ONNX Runtime supports Windows 10 and above, only.:UserWarning",
+  "ignore:Ignoring unexpected keyword arguments for UniformWater.*:UserWarning",
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/src/openlifu/seg/seg_method.py
+++ b/src/openlifu/seg/seg_method.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import inspect
-import warnings
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Annotated, Any, Literal
@@ -71,7 +71,7 @@ class SegmentationMethod(ABC):
             if on_keyword_mismatch == 'raise':
                 raise TypeError(f"Unexpected keyword arguments for {short_classname}: {unexpected_keywords}")
             elif on_keyword_mismatch == 'warn':
-                warnings.warn(f"Ignoring unexpected keyword arguments for {short_classname}: {unexpected_keywords}", stacklevel=2)
+                logging.warning(f"Ignoring unexpected keyword arguments for {short_classname}: {unexpected_keywords}")
             for k in unexpected_keywords:
                 d.pop(k)
 

--- a/src/openlifu/seg/seg_methods/uniform.py
+++ b/src/openlifu/seg/seg_methods/uniform.py
@@ -37,6 +37,12 @@ class UniformTissue(UniformSegmentation):
         records = [{"Name": "Type", "Value": "Uniform Tissue", "Unit": ""}]
         return pd.DataFrame.from_records(records)
 
+    def to_dict(self):
+        d = super().to_dict()
+        d.pop("ref_material")
+        return d
+
+
 class UniformWater(UniformSegmentation):
     """ Assigns the water material to all voxels in the volume. """
     def __init__(self, materials: dict[str, Material] | None = None):
@@ -52,3 +58,8 @@ class UniformWater(UniformSegmentation):
         """
         records = [{"Name": "Type", "Value": "Uniform Water", "Unit": ""}]
         return pd.DataFrame.from_records(records)
+
+    def to_dict(self):
+        d = super().to_dict()
+        d.pop("ref_material")
+        return d

--- a/tests/test_seg_method.py
+++ b/tests/test_seg_method.py
@@ -87,9 +87,6 @@ def test_from_dict_on_keyword_mismatch():
         "ref_material": "water"
     }
 
-    with pytest.warns(UserWarning):
-        SegmentationMethod.from_dict(d, on_keyword_mismatch='warn')
-
     with pytest.raises(TypeError, match=r"Unexpected keyword arguments for UniformWater: \['ref_material'\]"):
         SegmentationMethod.from_dict(d, on_keyword_mismatch='raise')
 

--- a/tests/test_seg_method.py
+++ b/tests/test_seg_method.py
@@ -70,3 +70,28 @@ def test_uniformwater_errors_when_specify_ref_material():
 def test_materials_as_none_gets_default_materials():
     seg_method = seg_methods.UniformSegmentation(materials=None)  # pyright: ignore[reportArgumentType]
     assert seg_method.materials == MATERIALS.copy()
+
+def test_from_dict_on_keyword_mismatch():
+    d = {
+        "class": "UniformWater",
+        "materials": {
+            "water": {
+                "name": "water",
+                "sound_speed": 1500,
+                "density": 1000,
+                "attenuation": 0.0022,
+                "specific_heat": 4182,
+                "thermal_conductivity": 0.598
+            }
+        },
+        "ref_material": "water"
+    }
+
+    with pytest.warns(UserWarning):
+        SegmentationMethod.from_dict(d, on_keyword_mismatch='warn')
+
+    with pytest.raises(TypeError, match=r"Unexpected keyword arguments for UniformWater: \['ref_material'\]"):
+        SegmentationMethod.from_dict(d, on_keyword_mismatch='raise')
+
+    # This should not raise any warning or exception
+    SegmentationMethod.from_dict(d, on_keyword_mismatch='ignore')


### PR DESCRIPTION
Removes the special-case handling for `UniformWater` and `UniformTissue` in `SegmentationMethod.from_dict`. Each subclass now overrides `to_dict` to exclude the `ref_material` attribute, which is implicit in the class and not a constructor argument.

`SegmentationMethod.from_dict` now checks for unexpected keywords and handles them based on the `on_keyword_mismatch` parameter. This allows for graceful handling of old JSON files that may contain the `ref_material` keyword.

Closes #362 