### PR TITLE
Remove validate-pyproject pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,12 +76,6 @@ repos:
         entry: PyBind|Numpy|Cmake|CCache|Github|PyTest
         exclude: .pre-commit-config.yaml
 
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: "v0.16"
-    hooks:
-      - id: validate-pyproject
-        additional_dependencies: ["validate-pyproject-schema-store[all]"]
-
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.28.2"
     hooks:


### PR DESCRIPTION
The validate-pyproject hook can be brittle. It relies on daily automated releases from a json schema store.

The value this hook provides is relatively low since configuration errors in tool sections (ruff, mypy, pytest, etc.) are already caught when those tools run, and build metadata errors are caught by the build system itself.

Maybe it's nice to have pre-commit complain when the pyproject.toml is wrong before you even build anything ... but it's not worth the extra layer of brittleness I think

(The alternative to simply removing validate-pyproject is to pin it to a version that didn't have the issue, or to just wait until they fix it which has historically been very quick, like next day, but I'm proposing just removing it.)