### PR TITLE
Add threshold-based MRI segmentation and phase correction (#150)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,6 @@ jobs:
           --durations=20
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v6.0.0
+        uses: codecov/codecov-action@v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,11 @@ filterwarnings = [
   "ignore:Custom binary name set.*:UserWarning",
   # pyparsing 3.x deprecated all camelCase methods in favor of snake_case
   "ignore:'[a-zA-Z]+' deprecated - use '[a-z_]+':DeprecationWarning",
+  # SimpleITK's SWIG bindings emit DeprecationWarnings about missing __module__
+  # attributes on builtin types during import. These are harmless and cannot be
+  # fixed downstream; suppressing them prevents a segfault when filterwarnings=error
+  # turns them into exceptions inside the C extension loader.
+  "ignore:builtin type Swig.*has no __module__ attribute:DeprecationWarning",
 ]
 log_cli_level = "INFO"
 testpaths = [

--- a/src/openlifu/bf/delay_methods/__init__.py
+++ b/src/openlifu/bf/delay_methods/__init__.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from .delaymethod import DelayMethod
 from .direct import Direct
+from .simulation_corrected import SimulationCorrected
 
 __all__ = [
     "DelayMethod",
     "Direct",
+    "SimulationCorrected",
 ]

--- a/src/openlifu/bf/delay_methods/simulation_corrected.py
+++ b/src/openlifu/bf/delay_methods/simulation_corrected.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Annotated
+
+import numpy as np
+import pandas as pd
+import xarray as xa
+
+from openlifu.bf.delay_methods import DelayMethod
+from openlifu.geo import Point
+from openlifu.util.annotations import OpenLIFUFieldData
+from openlifu.util.units import getunitconversion
+from openlifu.xdc import Transducer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SimulationCorrected(DelayMethod):
+    """Delay method using k-wave simulation with reciprocity for phase correction.
+
+    Places a virtual point source at the target and records pressure time series
+    at all transducer element positions. The arrival time at each element encodes
+    the true acoustic path through the heterogeneous skull model. Delays are
+    computed as max(arrival_time) - arrival_time for each element.
+
+    Uses a single k-wave simulation (via reciprocity) instead of one per element.
+    """
+
+    c0: Annotated[
+        float,
+        OpenLIFUFieldData("Speed of Sound (m/s)", "Reference speed of sound in the medium (m/s)"),
+    ] = 1500.0
+    """Reference speed of sound in the medium (m/s)"""
+
+    cfl: Annotated[float, OpenLIFUFieldData("CFL Number", "Courant-Friedrichs-Lewy number for time stepping")] = 0.3
+    """Courant-Friedrichs-Lewy number for time stepping"""
+
+    n_cycles: Annotated[int, OpenLIFUFieldData("Source Cycles", "Number of cycles in the source pulse")] = 3
+    """Number of cycles in the source pulse"""
+
+    gpu: Annotated[bool, OpenLIFUFieldData("Use GPU", "Whether to attempt GPU-accelerated simulation")] = True
+    """Whether to attempt GPU-accelerated simulation"""
+
+    def __post_init__(self):
+        if not isinstance(self.c0, int | float):
+            raise TypeError("Speed of sound must be a number")
+        if self.c0 <= 0:
+            raise ValueError("Speed of sound must be greater than 0")
+        self.c0 = float(self.c0)
+
+        if not isinstance(self.cfl, int | float):
+            raise TypeError("CFL must be a number")
+        if self.cfl <= 0 or self.cfl >= 1:
+            raise ValueError("CFL must be between 0 and 1 (exclusive)")
+        self.cfl = float(self.cfl)
+
+        if not isinstance(self.n_cycles, int):
+            if isinstance(self.n_cycles, float) and self.n_cycles == int(self.n_cycles):
+                self.n_cycles = int(self.n_cycles)
+            else:
+                raise TypeError("n_cycles must be an integer")
+        if self.n_cycles < 1:
+            raise ValueError("n_cycles must be at least 1")
+
+        if not isinstance(self.gpu, bool):
+            raise TypeError("gpu must be a boolean")
+
+    def calc_delays(self, arr: Transducer, target: Point, params: xa.Dataset, transform: np.ndarray | None = None):
+        """Calculate delays using k-wave simulation with reciprocity.
+
+        Fires a virtual point source at the target position and records the pressure
+        time series at each transducer element location. Arrival times are extracted
+        via the Hilbert envelope peak, and delays are computed so that all elements
+        fire in phase at the target.
+
+        Falls back to Direct (geometric) delays if k-wave is not available or
+        if the simulation fails for any reason.
+
+        Args:
+        :param arr: The transducer array.
+        :param target: The focal target point.
+        :param params: Simulation grid dataset with sound_speed, density, attenuation fields.
+        :param transform: Optional 4x4 affine transform for element positions.
+        :returns: 1D numpy array of per-element delays in seconds.
+        """
+        try:
+            import importlib
+            if importlib.util.find_spec("kwave") is None:
+                raise ImportError("k-wave not installed")
+        except ImportError:
+            logger.warning("k-wave not available. Falling back to Direct delay method.")
+            return self._fallback_delays(arr, target, params, transform)
+
+        try:
+            arrival_times = self._run_reciprocal_simulation(arr, target, params, transform)
+            delays = np.max(arrival_times) - arrival_times
+            return delays
+        except (RuntimeError, ValueError, IndexError, OSError):
+            logger.exception("Simulation-corrected delay calculation failed. Falling back to Direct method.")
+            return self._fallback_delays(arr, target, params, transform)
+
+    def _run_reciprocal_simulation(
+        self,
+        arr: Transducer,
+        target: Point,
+        params: xa.Dataset,
+        transform: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Run the reciprocal k-wave simulation and extract arrival times.
+
+        Args:
+            arr: The transducer array.
+            target: The focal target point.
+            params: Simulation grid dataset.
+            transform: Optional 4x4 affine transform.
+
+        Returns:
+            arrival_times: 1D array of arrival times (seconds) per element.
+        """
+        from scipy.signal import hilbert
+
+        from openlifu.sim.kwave_if import run_point_source_simulation
+
+        # Get the reference sound speed from params if available
+        if 'sound_speed' in params and 'ref_value' in params['sound_speed'].attrs:
+            sound_speed_ref = params['sound_speed'].attrs['ref_value']
+        else:
+            sound_speed_ref = self.c0
+
+        # Get frequency from the transducer
+        freq = arr.frequency
+
+        # Compute element positions in the simulation coordinate frame.
+        # The simulation grid uses params.coords (typically in mm).
+        # Element positions come from the transducer in its native units (typically m).
+        # We need to convert element positions to the same units as the sim grid,
+        # then find the nearest grid voxel for each element.
+        coord_dims = list(params.coords.dims)
+        coord_units = params[coord_dims[0]].attrs.get('units', 'mm')
+        scl_to_grid = getunitconversion('m', coord_units)
+
+        matrix = transform if transform is not None else np.eye(4)
+        element_positions_m = np.array([
+            el.get_position(units="m", matrix=matrix)
+            for el in arr.elements
+        ])
+        # Convert to grid units
+        element_positions_grid = element_positions_m * scl_to_grid
+
+        # Get target position in grid units
+        target_pos_grid = target.get_position(units=coord_units)
+
+        # Build the sensor mask: find nearest grid indices for each element
+        coord_arrays = [params.coords[dim].to_numpy() for dim in coord_dims]
+        grid_shape = tuple(len(c) for c in coord_arrays)
+
+        sensor_indices = []
+        out_of_grid = set()
+        for el_i, epos in enumerate(element_positions_grid):
+            idx = []
+            inside = True
+            for dim_i, coord_vals in enumerate(coord_arrays):
+                cmin, cmax = float(coord_vals[0]), float(coord_vals[-1])
+                half_step = abs(float(coord_vals[1] - coord_vals[0])) / 2 if len(coord_vals) > 1 else 0
+                if epos[dim_i] < cmin - half_step or epos[dim_i] > cmax + half_step:
+                    inside = False
+                nearest_idx = int(np.argmin(np.abs(coord_vals - epos[dim_i])))
+                idx.append(nearest_idx)
+            if not inside:
+                out_of_grid.add(el_i)
+                logger.warning(
+                    f"Element {el_i} at position {epos} is outside the simulation grid. "
+                    "Using geometric time-of-flight estimate for this element."
+                )
+            sensor_indices.append(tuple(idx))
+
+        # Build sensor mask (3D binary)
+        sensor_mask = np.zeros(grid_shape, dtype=int)
+        for idx in sensor_indices:
+            sensor_mask[idx] = 1
+
+        # Find the target voxel index, with out-of-grid check
+        target_idx = []
+        for dim_i, coord_vals in enumerate(coord_arrays):
+            cmin, cmax = float(coord_vals[0]), float(coord_vals[-1])
+            half_step = abs(float(coord_vals[1] - coord_vals[0])) / 2 if len(coord_vals) > 1 else 0
+            if target_pos_grid[dim_i] < cmin - half_step or target_pos_grid[dim_i] > cmax + half_step:
+                logger.warning(
+                    "Target position %s is outside the simulation grid on axis %d. "
+                    "Falling back to geometric delays.",
+                    target_pos_grid, dim_i,
+                )
+                raise ValueError("Target outside simulation grid")
+            nearest_idx = int(np.argmin(np.abs(coord_vals - target_pos_grid[dim_i])))
+            target_idx.append(nearest_idx)
+        target_idx = tuple(target_idx)
+
+        # Build source mask (single voxel at target)
+        source_mask = np.zeros(grid_shape, dtype=int)
+        source_mask[target_idx] = 1
+
+        # Run the point source simulation
+        sensor_data, dt = run_point_source_simulation(
+            params=params,
+            source_mask=source_mask,
+            sensor_mask=sensor_mask,
+            freq=freq,
+            n_cycles=self.n_cycles,
+            sound_speed_ref=sound_speed_ref,
+            cfl=self.cfl,
+            gpu=self.gpu,
+        )
+
+        # sensor_data is (n_sensor_points, n_timesteps).
+        # Multiple elements may map to the same voxel if the grid is coarse.
+        # We need to map sensor data rows back to elements.
+
+        # Build a lookup: grid index -> sensor_data row index.
+        # The sensor mask was constructed by setting 1 at unique voxel locations.
+        # k-wave returns data for each nonzero voxel in Fortran (column-major) order.
+        nonzero_indices = list(zip(*np.nonzero(sensor_mask)))
+        # k-wave returns sensor data in Fortran (column-major) order of the mask:
+        # x varies fastest, then y, then z. np.nonzero returns C order (row-major),
+        # so we sort by the Fortran linear index to match k-wave's output ordering.
+        def fortran_linear_index(idx, shape):
+            # For Fortran order: idx[0] + idx[1]*shape[0] + idx[2]*shape[0]*shape[1]
+            lin = idx[0]
+            stride = shape[0]
+            for d in range(1, len(shape)):
+                lin += idx[d] * stride
+                stride *= shape[d]
+            return lin
+
+        nonzero_with_fortran = [(fortran_linear_index(idx, grid_shape), idx) for idx in nonzero_indices]
+        nonzero_with_fortran.sort(key=lambda x: x[0])
+        sorted_nonzero = [item[1] for item in nonzero_with_fortran]
+
+        voxel_to_row = {idx: row for row, idx in enumerate(sorted_nonzero)}
+
+        # Extract arrival time for each element
+        n_elements = len(arr.elements)
+        arrival_times = np.zeros(n_elements)
+
+        for el_i, sensor_idx in enumerate(sensor_indices):
+            if el_i in out_of_grid:
+                # Element is outside the simulation grid; use geometric fallback
+                dist = np.linalg.norm(element_positions_m[el_i] - target.get_position(units="m"))
+                arrival_times[el_i] = dist / self.c0
+                continue
+
+            row = voxel_to_row[sensor_idx]
+            time_series = sensor_data[row, :]
+            # Compute the analytic signal envelope via the Hilbert transform
+            analytic = hilbert(time_series)
+            envelope = np.abs(analytic)
+            # The arrival time is the time of the envelope peak
+            peak_sample = int(np.argmax(envelope))
+            arrival_times[el_i] = peak_sample * dt
+
+        return arrival_times
+
+    def _fallback_delays(self, arr: Transducer, target: Point, params: xa.Dataset, transform: np.ndarray | None = None) -> np.ndarray:
+        """Compute delays using the Direct (geometric) method as a fallback."""
+        from openlifu.bf.delay_methods.direct import Direct
+        direct = Direct(c0=self.c0)
+        return direct.calc_delays(arr, target, params, transform)
+
+    def to_table(self) -> pd.DataFrame:
+        """
+        Get a table of the delay method parameters
+
+        :returns: Pandas DataFrame of the delay method parameters
+        """
+        records = [
+            {"Name": "Type", "Value": "SimulationCorrected", "Unit": ""},
+            {"Name": "Default Sound Speed", "Value": self.c0, "Unit": "m/s"},
+            {"Name": "CFL Number", "Value": self.cfl, "Unit": ""},
+            {"Name": "Source Cycles", "Value": self.n_cycles, "Unit": ""},
+            {"Name": "Use GPU", "Value": self.gpu, "Unit": ""},
+        ]
+        return pd.DataFrame.from_records(records)

--- a/src/openlifu/bf/delay_methods/simulation_corrected.py
+++ b/src/openlifu/bf/delay_methods/simulation_corrected.py
@@ -248,7 +248,7 @@ class SimulationCorrected(DelayMethod):
             if el_i in out_of_grid:
                 # Element is outside the simulation grid; use geometric fallback
                 dist = np.linalg.norm(element_positions_m[el_i] - target.get_position(units="m"))
-                arrival_times[el_i] = dist / self.c0
+                arrival_times[el_i] = dist / sound_speed_ref
                 continue
 
             row = voxel_to_row[sensor_idx]

--- a/src/openlifu/seg/material.py
+++ b/src/openlifu/seg/material.py
@@ -92,28 +92,28 @@ class Material:
 WATER = Material(name="water",
                  sound_speed=1500.0,
                  density=1000.0,
-                 attenuation=0.0,
+                 attenuation=0.002,
                  specific_heat=4182.0,
                  thermal_conductivity=0.598)
 
 TISSUE = Material(name="tissue",
                   sound_speed=1540.0,
                   density=1000.0,
-                  attenuation=0.0,
+                  attenuation=0.6,
                   specific_heat=3600.0,
                   thermal_conductivity=0.5)
 
 SKULL = Material(name="skull",
                  sound_speed=4080.0,
                  density=1900.0,
-                 attenuation=0.0,
+                 attenuation=8.0,
                  specific_heat=1100.0,
                  thermal_conductivity=0.3)
 
 AIR = Material(name="air",
                sound_speed=344.0,
                density=1.25,
-               attenuation=0.0,
+               attenuation=1.64,
                specific_heat=1012.0,
                thermal_conductivity=0.025)
 

--- a/src/openlifu/seg/seg_methods/__init__.py
+++ b/src/openlifu/seg/seg_methods/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from .threshold_mri import ThresholdMRI
 from .uniform import UniformSegmentation, UniformTissue, UniformWater
 
 __all__ = [
+    "ThresholdMRI",
     "UniformSegmentation",
-    "UniformWater",
     "UniformTissue",
+    "UniformWater",
 ]

--- a/src/openlifu/seg/seg_methods/threshold_mri.py
+++ b/src/openlifu/seg/seg_methods/threshold_mri.py
@@ -93,14 +93,8 @@ class ThresholdMRI(SegmentationMethod):
     is labeled as a single "tissue" material. The segmentation assigns four
     tissue types: water, skull, tissue, and air. When True, the brain
     interior is split into CSF, gray matter, and white matter using a
-    3-component Gaussian Mixture Model (EM-GMM) on T1-weighted intensity,
-    with optional spatial regularization. Two regularization modes are
-    available: Markov Random Field (MRF) via Iterated Conditional Modes
-    (ICM) when ``mrf_beta > 0``, or Gaussian smoothing of posterior
-    probability maps when ``spatial_sigma_mm > 0``. Both are disabled by
-    default. MRF regularization preserves tissue boundaries better than
-    Gaussian smoothing by penalizing label disagreement among 6-connected
-    neighbors without blurring probability maps. This yields a total of six assigned tissue types:
+    3-component Gaussian Mixture Model (EM-GMM) on T1-weighted intensity.
+    This yields a total of six assigned tissue types:
     water, skull, csf, gray_matter, white_matter, and air. Additional
     materials in the dict (e.g. standoff) are carried through but not
     assigned by the segmentation algorithm.
@@ -146,7 +140,7 @@ class ThresholdMRI(SegmentationMethod):
         OpenLIFUFieldData(
             "Classify brain tissues",
             "If True, classify brain interior into CSF, gray matter, and white matter "
-            "using a spatially-regularized EM-GMM on T1-weighted intensity",
+            "using an EM-GMM on T1-weighted intensity",
         ),
     ] = False
     """If True, sub-classify brain interior into CSF, gray matter, and white matter."""
@@ -172,38 +166,6 @@ class ThresholdMRI(SegmentationMethod):
     ] = True
     """If True, use SimpleITK N4BiasFieldCorrection for bias correction.
     Falls back to homomorphic if SimpleITK is not available."""
-
-    spatial_sigma_mm: Annotated[
-        float,
-        OpenLIFUFieldData(
-            "Spatial regularization sigma (mm)",
-            "Gaussian smoothing sigma for spatial regularization of brain tissue "
-            "probability maps. Set to 0 to disable. Only used when classify_brain_tissues is True "
-            "and mrf_beta is 0.",
-        ),
-    ] = 0.0
-    """Gaussian smoothing sigma (mm) for spatial regularization.
-    Defaults to 0 (disabled). Non-zero values apply masked Gaussian
-    smoothing to posterior probability maps before label assignment.
-    Smoothing is confined to the parenchyma mask to prevent boundary leakage.
-    Ignored when mrf_beta > 0 (MRF regularization takes precedence)."""
-
-    mrf_beta: Annotated[
-        float,
-        OpenLIFUFieldData(
-            "MRF regularization strength",
-            "Markov Random Field regularization parameter (beta) for brain tissue "
-            "classification. Controls the penalty for label disagreement among "
-            "6-connected neighbors via Iterated Conditional Modes (ICM). "
-            "Set to 0 to disable MRF and fall back to Gaussian smoothing. "
-            "Typical values are 0.1-0.3. Only used when classify_brain_tissues is True.",
-        ),
-    ] = 0.0
-    """MRF regularization strength (beta).
-    Defaults to 0 (disabled). When positive, Iterated Conditional Modes (ICM) is used
-    for spatial regularization instead of Gaussian smoothing. Higher values
-    produce smoother label maps but may over-regularize thin structures.
-    Set to 0 to disable MRF and use Gaussian smoothing (spatial_sigma_mm) instead."""
 
     brain_extraction_margin_mm: Annotated[
         float,
@@ -272,12 +234,6 @@ class ThresholdMRI(SegmentationMethod):
             raise ValueError(msg)
         if self.bias_correction_sigma_mm < 0:
             msg = f"bias_correction_sigma_mm must be non-negative, got {self.bias_correction_sigma_mm}."
-            raise ValueError(msg)
-        if self.spatial_sigma_mm < 0:
-            msg = f"spatial_sigma_mm must be non-negative, got {self.spatial_sigma_mm}."
-            raise ValueError(msg)
-        if self.mrf_beta < 0:
-            msg = f"mrf_beta must be non-negative, got {self.mrf_beta}."
             raise ValueError(msg)
         if self.brain_extraction_margin_mm < 0:
             msg = f"brain_extraction_margin_mm must be non-negative, got {self.brain_extraction_margin_mm}."
@@ -745,59 +701,6 @@ class ThresholdMRI(SegmentationMethod):
         order = np.argsort(means)
         return means[order], stds[order], weights[order]
 
-    @staticmethod
-    def _icm_iteration(
-        seg_arr: np.ndarray,
-        log_likelihoods: np.ndarray,
-        parenchyma_mask: np.ndarray,
-        label_indices: list[int],
-        beta: float,
-    ) -> np.ndarray:
-        """One pass of Iterated Conditional Modes (ICM) for MRF regularization.
-
-        For each voxel in the parenchyma mask, computes a posterior that
-        combines the GMM log-likelihood with a spatial prior that counts
-        how many of the 6-connected (face) neighbors share the same label.
-        The voxel is assigned to the class that maximizes this posterior.
-
-        Uses vectorized numpy operations (np.roll along each axis) rather
-        than per-voxel loops for performance.
-
-        :param seg_arr: Current integer label array (modified in-place)
-        :param log_likelihoods: Log-likelihood for each class, shape (n_classes, *vol_shape)
-        :param parenchyma_mask: Boolean mask restricting ICM updates
-        :param label_indices: Integer label values for each class (same order as log_likelihoods)
-        :param beta: MRF regularization strength
-        :returns: Updated seg_arr (same object, modified in-place)
-        """
-        n_classes = log_likelihoods.shape[0]
-
-        # For each class k, count how many of the 6 face-neighbors share
-        # label k. np.roll wraps at boundaries, but boundary voxels are
-        # typically outside the parenchyma mask and do not affect the result.
-        neighbor_agreement = np.zeros(
-            (n_classes, *seg_arr.shape), dtype=np.float32
-        )
-        for k, label_val in enumerate(label_indices):
-            same_label = (seg_arr == label_val).astype(np.float32)
-            agreement = np.zeros_like(same_label)
-            for axis in range(3):
-                agreement += np.roll(same_label, 1, axis=axis)
-                agreement += np.roll(same_label, -1, axis=axis)
-            neighbor_agreement[k] = agreement  # Range 0..6
-
-        # Posterior = log_likelihood + beta * neighbor_agreement.
-        # Higher agreement means more neighbors share this label, which is
-        # rewarded. This is equivalent to penalizing disagreement.
-        posterior = log_likelihoods + beta * neighbor_agreement
-
-        # Assign each voxel to the class with the highest posterior.
-        best_class = np.argmax(posterior, axis=0)
-        for k, label_val in enumerate(label_indices):
-            seg_arr[parenchyma_mask & (best_class == k)] = label_val
-
-        return seg_arr
-
     def _classify_brain(
         self,
         data: np.ndarray,
@@ -811,9 +714,9 @@ class ThresholdMRI(SegmentationMethod):
 
         Modifies ``seg`` in-place. Optionally applies bias field correction,
         then fits a 3-component Gaussian Mixture Model (EM-GMM) to the
-        (possibly tighter) GMM parenchyma mask. Posterior probability maps are
-        spatially smoothed with a Gaussian kernel for regularization, and the
-        process is iterated twice to refine the classification.
+        (possibly tighter) GMM parenchyma mask. Labels are assigned via
+        argmax of the posterior probabilities, iterated twice to refine
+        the GMM parameters.
 
         After GMM classification within the tight mask, labels are expanded
         to cover the full parenchyma mask via nearest-neighbor assignment
@@ -845,7 +748,7 @@ class ThresholdMRI(SegmentationMethod):
 
         try:
             self._classify_brain_gmm(
-                classify_data, gmm_parenchyma_mask, seg, material_idx, spacing
+                classify_data, gmm_parenchyma_mask, seg, material_idx
             )
         except (RuntimeError, ValueError, np.linalg.LinAlgError):
             logging.warning(
@@ -875,19 +778,12 @@ class ThresholdMRI(SegmentationMethod):
         parenchyma_mask: np.ndarray,
         seg: np.ndarray,
         material_idx: dict[str, int],
-        spacing: np.ndarray,
     ) -> None:
-        """Core GMM classification with spatial regularization.
+        """Core GMM classification.
 
-        Fits a 3-component GMM, computes full-volume log-likelihood maps,
-        then applies spatial regularization. When ``mrf_beta > 0``, uses
-        Markov Random Field regularization via Iterated Conditional Modes
-        (ICM), which penalizes label disagreement among 6-connected
-        neighbors while preserving tissue boundaries. When ``mrf_beta == 0``
-        and ``spatial_sigma_mm > 0``, falls back to Gaussian smoothing of
-        posterior probability maps. The outer loop iterates twice: after
-        each regularization pass, GMM parameters are re-estimated from the
-        current labels/posteriors.
+        Fits a 3-component GMM to parenchyma voxel intensities, computes
+        posterior probabilities, assigns labels via argmax, then iterates
+        twice to refine GMM parameters from the current assignment.
 
         Called by ``_classify_brain``; raises on failure so the caller can
         apply the gray-matter fallback.
@@ -896,15 +792,11 @@ class ThresholdMRI(SegmentationMethod):
         :param parenchyma_mask: Boolean mask of brain parenchyma
         :param seg: Integer label array to modify in-place
         :param material_idx: Mapping from material name to integer label
-        :param spacing: Voxel spacing in mm per axis
         """
-        use_mrf = self.mrf_beta > 0
-        sigma_voxels = self.spatial_sigma_mm / spacing
         label_keys = ["csf", "gray_matter", "white_matter"]  # sorted by T1 mean
         label_indices = [material_idx[k] for k in label_keys]
         n_components = len(label_keys)
-        n_outer = 2  # total spatial-regularization iterations
-        n_icm = 5  # ICM iterations per outer loop (when using MRF)
+        n_outer = 2
 
         # Extract parenchyma intensities for the initial fit.
         parenchyma_vals = classify_data[parenchyma_mask]
@@ -923,144 +815,49 @@ class ThresholdMRI(SegmentationMethod):
         # Precompute constant for inline logpdf (avoids scipy overhead).
         _LOG_2PI_HALF = 0.5 * np.log(2.0 * np.pi)
 
-        # Determine whether we need full 3D probability maps.
-        # MRF needs 3D log-likelihoods for ICM; Gaussian smoothing needs 3D
-        # prob_maps for the convolution. When neither is active, we can
-        # compute likelihoods only at parenchyma voxels (flat arrays).
-        needs_3d = use_mrf or self.spatial_sigma_mm > 0
-
         for _iteration in range(n_outer):
             safe_stds = np.maximum(stds, 1e-10)
             log_weights = np.log(weights + 1e-300)
 
-            if needs_3d:
-                # Build full-volume log-likelihood maps (only inside parenchyma).
-                log_likelihoods = np.full(
-                    (n_components, *classify_data.shape), -np.inf, dtype=np.float64
-                )
-                prob_maps = np.zeros(
-                    (n_components, *classify_data.shape), dtype=np.float64
-                )
-                for k in range(n_components):
-                    z = (classify_data - means[k]) / safe_stds[k]
-                    log_prob = (
-                        -0.5 * z * z
-                        - np.log(safe_stds[k])
-                        - _LOG_2PI_HALF
-                        + log_weights[k]
-                    )
-                    log_likelihoods[k][parenchyma_mask] = log_prob[parenchyma_mask]
-                    prob_maps[k] = np.exp(log_prob)
-                    # Zero out non-parenchyma to avoid leakage.
-                    prob_maps[k][~parenchyma_mask] = 0.0
-            else:
-                # Fast path: compute likelihoods only at parenchyma voxels.
-                # shapes: parenchyma_vals = (M,), means = (K,)
-                z_flat = (parenchyma_vals[None, :] - means[:, None]) / safe_stds[:, None]
-                log_ll_flat = (
-                    -0.5 * z_flat * z_flat
-                    - np.log(safe_stds[:, None])
-                    - _LOG_2PI_HALF
-                    + log_weights[:, None]
-                )
-                prob_flat = np.exp(log_ll_flat)
+            # Compute likelihoods only at parenchyma voxels (flat arrays).
+            z_flat = (parenchyma_vals[None, :] - means[:, None]) / safe_stds[:, None]
+            log_ll_flat = (
+                -0.5 * z_flat * z_flat
+                - np.log(safe_stds[:, None])
+                - _LOG_2PI_HALF
+                + log_weights[:, None]
+            )
+            prob_flat = np.exp(log_ll_flat)
 
-            if use_mrf:
-                # MRF regularization via ICM.
-                # Initialize seg labels from the argmax of the raw likelihoods
-                # (only within the parenchyma mask) before ICM iterations.
-                init_labels = np.argmax(
-                    log_likelihoods[:, parenchyma_mask], axis=0
-                )
-                for k, label_val in enumerate(label_indices):
-                    mask_k = parenchyma_mask.copy()
-                    mask_k[parenchyma_mask] = init_labels == k
-                    seg[mask_k] = label_val
+            # Normalize posteriors.
+            prob_sum_flat = np.sum(prob_flat, axis=0)
+            prob_sum_flat[prob_sum_flat < 1e-300] = 1e-300
+            prob_flat /= prob_sum_flat
 
-                # Run ICM iterations to refine labels using spatial context.
-                for _icm_iter in range(n_icm):
-                    self._icm_iteration(
-                        seg, log_likelihoods, parenchyma_mask,
-                        label_indices, self.mrf_beta,
-                    )
-
-                # Build soft responsibilities from the final labels for
-                # GMM re-estimation. Use the normalized likelihoods (posteriors)
-                # so the M-step is consistent with the E-step.
-                prob_sum = np.sum(prob_maps, axis=0)
-                prob_sum[prob_sum < 1e-300] = 1e-300
-                for k in range(n_components):
-                    prob_maps[k] /= prob_sum
-
-                # Extract labels from seg for final output.
-                labels_3d = np.zeros(int(np.sum(parenchyma_mask)), dtype=int)
-                for k, label_val in enumerate(label_indices):
-                    labels_3d[seg[parenchyma_mask] == label_val] = k
-
-            elif self.spatial_sigma_mm > 0:
-                # Gaussian smoothing regularization path.
-                mask_float = parenchyma_mask.astype(np.float64)
-                smoothed_mask = gaussian_filter(mask_float, sigma=sigma_voxels)
-                safe = parenchyma_mask & (smoothed_mask > 1e-6)
-                for k in range(n_components):
-                    smoothed_prob = gaussian_filter(
-                        prob_maps[k] * mask_float, sigma=sigma_voxels
-                    )
-                    result = np.zeros_like(prob_maps[k])
-                    result[safe] = smoothed_prob[safe] / smoothed_mask[safe]
-                    prob_maps[k] = result
-
-                # Normalize posteriors within parenchyma.
-                prob_sum = np.sum(prob_maps, axis=0)
-                prob_sum[prob_sum < 1e-300] = 1e-300
-                for k in range(n_components):
-                    prob_maps[k] /= prob_sum
-
-                # Assign labels via argmax of smoothed posteriors.
-                labels_3d = np.argmax(prob_maps[:, parenchyma_mask], axis=0)
-
-            else:
-                # No spatial regularization: work entirely with flat arrays.
-                # Normalize posteriors at parenchyma voxels only.
-                prob_sum_flat = np.sum(prob_flat, axis=0)
-                prob_sum_flat[prob_sum_flat < 1e-300] = 1e-300
-                for k in range(n_components):
-                    prob_flat[k] /= prob_sum_flat
-
-                # Assign labels via argmax of posteriors.
-                labels_3d = np.argmax(prob_flat, axis=0)
-
-            # Re-estimate GMM parameters from the current soft assignment
-            # (for the next iteration). Use the posteriors as weights.
-            parenchyma_intensities = classify_data[parenchyma_mask]
+            # Re-estimate GMM parameters from the current soft assignment.
             new_means = np.empty(n_components)
             new_stds = np.empty(n_components)
             new_weights = np.empty(n_components)
             for k in range(n_components):
-                if needs_3d:
-                    resp_k = prob_maps[k][parenchyma_mask]
-                else:
-                    resp_k = prob_flat[k]
+                resp_k = prob_flat[k]
                 nk = np.sum(resp_k)
                 if nk < 1e-10:
                     new_means[k] = means[k]
                     new_stds[k] = stds[k]
                     new_weights[k] = weights[k]
                     continue
-                new_means[k] = np.dot(resp_k, parenchyma_intensities) / nk
-                diff = parenchyma_intensities - new_means[k]
+                new_means[k] = np.dot(resp_k, parenchyma_vals) / nk
+                diff = parenchyma_vals - new_means[k]
                 new_stds[k] = np.sqrt(np.dot(resp_k, diff * diff) / nk)
                 new_stds[k] = max(new_stds[k], 1e-10)
-                new_weights[k] = nk / len(parenchyma_intensities)
+                new_weights[k] = nk / len(parenchyma_vals)
 
             means, stds, weights = new_means, new_stds, new_weights
 
-        # Write final labels into seg. Components are sorted by mean:
-        # index 0 = CSF (lowest), 1 = gray matter, 2 = white matter (highest).
-        for k, key in enumerate(label_keys):
-            voxel_mask = parenchyma_mask.copy()
-            voxel_mask[parenchyma_mask] = labels_3d == k
-            seg[voxel_mask] = material_idx[key]
+        # Assign final labels from the last iteration's posteriors.
+        # Components are sorted by mean: 0=CSF, 1=gray matter, 2=white matter.
+        labels_flat = np.argmax(prob_flat, axis=0)
+        seg[parenchyma_mask] = np.array(label_indices)[labels_flat]
 
     def to_table(self) -> pd.DataFrame:
         """
@@ -1075,8 +872,6 @@ class ThresholdMRI(SegmentationMethod):
             {"Name": "Classify Brain Tissues", "Value": self.classify_brain_tissues, "Unit": ""},
             {"Name": "Bias Correction Sigma", "Value": self.bias_correction_sigma_mm, "Unit": "mm"},
             {"Name": "Use N4", "Value": self.use_n4, "Unit": ""},
-            {"Name": "Spatial Regularization Sigma", "Value": self.spatial_sigma_mm, "Unit": "mm"},
-            {"Name": "MRF Beta", "Value": self.mrf_beta, "Unit": ""},
             {"Name": "Brain Extraction Margin", "Value": self.brain_extraction_margin_mm, "Unit": "mm"},
             {"Name": "Refine Skull Intensity", "Value": self.refine_skull_intensity, "Unit": ""},
             {"Name": "Reference Material", "Value": self.ref_material, "Unit": ""},

--- a/src/openlifu/seg/seg_methods/threshold_mri.py
+++ b/src/openlifu/seg/seg_methods/threshold_mri.py
@@ -909,6 +909,12 @@ class ThresholdMRI(SegmentationMethod):
         # Extract parenchyma intensities for the initial fit.
         parenchyma_vals = classify_data[parenchyma_mask]
 
+        # Guard against near-constant intensity distributions where a
+        # 3-component GMM would be degenerate (all components collapse
+        # to the same mean, posteriors tie, argmax assigns class 0).
+        if float(np.ptp(parenchyma_vals)) < 1e-6:
+            raise ValueError("Parenchyma intensity range is near-zero; GMM cannot fit")
+
         # Initial GMM fit on raw parenchyma intensities.
         means, stds, weights = self._fit_gmm_1d(
             parenchyma_vals, n_components=n_components

--- a/src/openlifu/seg/seg_methods/threshold_mri.py
+++ b/src/openlifu/seg/seg_methods/threshold_mri.py
@@ -1,0 +1,1078 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Annotated
+
+import numpy as np
+import pandas as pd
+import xarray as xa
+from scipy.ndimage import distance_transform_edt, gaussian_filter
+
+from openlifu.seg.material import MATERIALS, Material
+from openlifu.seg.seg_method import SegmentationMethod
+from openlifu.seg.skinseg import compute_foreground_mask
+from openlifu.util.annotations import OpenLIFUFieldData
+
+# Literature-backed material definitions for brain tissue subtypes.
+#
+# Sound speed: Labuda et al. 2022 (Ultrasonics, vol. 124, 106742) found no
+# significant difference in speed of sound between gray and white matter,
+# reporting 1532-1541 m/s across specimens. We use 1540 m/s for both GM and
+# WM, consistent with the Aubry 2022 JASA benchmark (1560 m/s for
+# undifferentiated brain) and IT'IS (1546 m/s). CSF speed of sound from
+# IT'IS Foundation via Mueller et al. 2016 (J Neural Eng 13(5):056002).
+#
+# Density: IT'IS Foundation (BfS-2018-3615S82433 report).
+#   GM: 1045 kg/m3, WM: 1041 kg/m3, CSF: 1007 kg/m3.
+#
+# Attenuation: Labuda et al. 2022 measured significantly higher attenuation
+# in WM than GM. Values in Np/m from BabelBrain (Pichardo), derived by
+# averaging IT'IS (0.25-0.75 MHz) and Labuda 2022 (3.5-10 MHz):
+#   GM: 4.40 Np/m @ 1MHz -> 0.38 dB/cm/MHz
+#   WM: 10.18 Np/m @ 1MHz -> 0.88 dB/cm/MHz
+#   CSF: ~0.099 Np/m -> 0.009 dB/cm/MHz (essentially negligible)
+# Conversion: Np/m * (8.686 dB/Np) / (100 cm/m) = dB/cm; at 1 MHz this
+# equals dB/cm/MHz directly.
+#
+# Thermal properties: IT'IS Foundation (specific heat, thermal conductivity).
+CSF = Material(
+    name="csf",
+    sound_speed=1507.0,
+    density=1007.0,
+    attenuation=0.009,
+    specific_heat=4096.0,
+    thermal_conductivity=0.57,
+)
+GRAY_MATTER = Material(
+    name="gray_matter",
+    sound_speed=1540.0,
+    density=1045.0,
+    attenuation=0.38,
+    specific_heat=3696.0,
+    thermal_conductivity=0.55,
+)
+WHITE_MATTER = Material(
+    name="white_matter",
+    sound_speed=1540.0,
+    density=1041.0,
+    attenuation=0.88,
+    specific_heat=3583.0,
+    thermal_conductivity=0.48,
+)
+
+_BASE_MATERIAL_KEYS = frozenset({"water", "skull", "air"})
+_BRAIN_UNIFORM_KEYS = frozenset({"tissue"})
+_BRAIN_CLASSIFIED_KEYS = frozenset({"csf", "gray_matter", "white_matter"})
+
+
+def _default_materials_uniform() -> dict[str, Material]:
+    return MATERIALS.copy()
+
+
+def _default_materials_classified() -> dict[str, Material]:
+    """Default materials dict when brain tissue classification is enabled."""
+    m = MATERIALS.copy()
+    # Remove the generic "tissue" and add the three brain subtypes.
+    m.pop("tissue", None)
+    m["csf"] = CSF
+    m["gray_matter"] = GRAY_MATTER
+    m["white_matter"] = WHITE_MATTER
+    return m
+
+
+@dataclass
+class ThresholdMRI(SegmentationMethod):
+    """MRI-based segmentation using intensity thresholding and distance transforms.
+
+    Segments an MRI volume into skull (outer shell), air (low-intensity
+    cavities), and brain tissue regions, with optional sub-classification
+    of brain tissue into CSF, gray matter, and white matter.
+
+    When ``classify_brain_tissues`` is False (default), the brain interior
+    is labeled as a single "tissue" material. The segmentation assigns four
+    tissue types: water, skull, tissue, and air. When True, the brain
+    interior is split into CSF, gray matter, and white matter using a
+    3-component Gaussian Mixture Model (EM-GMM) on T1-weighted intensity,
+    with optional spatial regularization. Two regularization modes are
+    available: Markov Random Field (MRF) via Iterated Conditional Modes
+    (ICM) when ``mrf_beta > 0``, or Gaussian smoothing of posterior
+    probability maps when ``spatial_sigma_mm > 0``. Both are disabled by
+    default. MRF regularization preserves tissue boundaries better than
+    Gaussian smoothing by penalizing label disagreement among 6-connected
+    neighbors without blurring probability maps. This yields a total of six assigned tissue types:
+    water, skull, csf, gray_matter, white_matter, and air. Additional
+    materials in the dict (e.g. standoff) are carried through but not
+    assigned by the segmentation algorithm.
+
+    The algorithm assumes standard T1-weighted MRI contrast where the head
+    is brighter than background, and within the brain, white matter is
+    brightest, gray matter intermediate, and CSF darkest. Volumes with
+    different contrast (e.g. T2-weighted) will not classify brain tissues
+    correctly.
+
+    Each axis of the input volume must have at least 2 coordinate values
+    so that voxel spacing can be computed. Coordinate spacing is assumed
+    to be uniform along each axis.
+    """
+
+    skull_thickness_mm: Annotated[
+        float,
+        OpenLIFUFieldData(
+            "Skull thickness (mm)",
+            "Approximate skull thickness used to define the skull shell via erosion",
+        ),
+    ] = 12.0
+    """Approximate skull thickness in millimeters used to define the skull shell via erosion."""
+
+    air_threshold_quantile: Annotated[
+        float,
+        OpenLIFUFieldData(
+            "Air threshold quantile",
+            "Quantile of brain-interior voxel intensities below which voxels are classified as air. "
+            "An additional absolute-intensity guard requires the voxel to also be below 10% of the "
+            "median brain intensity, preventing dark-but-not-air tissue (e.g. CSF) from being "
+            "misclassified as air.",
+        ),
+    ] = 0.05
+    """Quantile of brain-interior voxel intensities below which voxels are classified as air.
+
+    A voxel is only labeled air if its intensity is both below this quantile
+    threshold and below 10% of the median brain intensity. This dual condition
+    prevents CSF (dark but with meaningful signal) from being classified as air."""
+
+    classify_brain_tissues: Annotated[
+        bool,
+        OpenLIFUFieldData(
+            "Classify brain tissues",
+            "If True, classify brain interior into CSF, gray matter, and white matter "
+            "using a spatially-regularized EM-GMM on T1-weighted intensity",
+        ),
+    ] = False
+    """If True, sub-classify brain interior into CSF, gray matter, and white matter."""
+
+    bias_correction_sigma_mm: Annotated[
+        float,
+        OpenLIFUFieldData(
+            "Bias correction sigma (mm)",
+            "Gaussian smoothing sigma for homomorphic bias field correction. "
+            "Set to 0 to disable. Only applied when classify_brain_tissues is True.",
+        ),
+    ] = 30.0
+    """Sigma in mm for bias field estimation. Larger values capture broader gradients.
+    Set to 0 to disable bias correction. Only used when classify_brain_tissues is True."""
+
+    use_n4: Annotated[
+        bool,
+        OpenLIFUFieldData(
+            "Use N4 bias correction",
+            "If True and SimpleITK is installed, use N4BiasFieldCorrection "
+            "instead of homomorphic correction. Requires SimpleITK.",
+        ),
+    ] = True
+    """If True, use SimpleITK N4BiasFieldCorrection for bias correction.
+    Falls back to homomorphic if SimpleITK is not available."""
+
+    spatial_sigma_mm: Annotated[
+        float,
+        OpenLIFUFieldData(
+            "Spatial regularization sigma (mm)",
+            "Gaussian smoothing sigma for spatial regularization of brain tissue "
+            "probability maps. Set to 0 to disable. Only used when classify_brain_tissues is True "
+            "and mrf_beta is 0.",
+        ),
+    ] = 0.0
+    """Gaussian smoothing sigma (mm) for spatial regularization.
+    Defaults to 0 (disabled). Non-zero values apply masked Gaussian
+    smoothing to posterior probability maps before label assignment.
+    Smoothing is confined to the parenchyma mask to prevent boundary leakage.
+    Ignored when mrf_beta > 0 (MRF regularization takes precedence)."""
+
+    mrf_beta: Annotated[
+        float,
+        OpenLIFUFieldData(
+            "MRF regularization strength",
+            "Markov Random Field regularization parameter (beta) for brain tissue "
+            "classification. Controls the penalty for label disagreement among "
+            "6-connected neighbors via Iterated Conditional Modes (ICM). "
+            "Set to 0 to disable MRF and fall back to Gaussian smoothing. "
+            "Typical values are 0.1-0.3. Only used when classify_brain_tissues is True.",
+        ),
+    ] = 0.0
+    """MRF regularization strength (beta).
+    Defaults to 0 (disabled). When positive, Iterated Conditional Modes (ICM) is used
+    for spatial regularization instead of Gaussian smoothing. Higher values
+    produce smoother label maps but may over-regularize thin structures.
+    Set to 0 to disable MRF and use Gaussian smoothing (spatial_sigma_mm) instead."""
+
+    brain_extraction_margin_mm: Annotated[
+        float,
+        OpenLIFUFieldData(
+            "Brain extraction margin (mm)",
+            "Extra erosion margin beyond the skull shell for the GMM classification mask. "
+            "Excludes dura, meninges, and cortical boundary tissues from the mixture model "
+            "to improve tissue classification accuracy. Labels are expanded back to the full "
+            "brain mask via nearest-neighbor assignment. Only used when classify_brain_tissues is True.",
+        ),
+    ] = 0.0
+    """Extra erosion in mm beyond the skull boundary for brain tissue classification.
+    On whole-head data, voxels just inside the skull (dura, meninges, cortical CSF)
+    have intensities that overlap with GM/WM and can contaminate the GMM. This margin
+    defines a tighter mask for the GMM fit; after classification, labels are propagated
+    back to the full brain mask using nearest-neighbor assignment. Set to 0 to disable.
+    Only used when classify_brain_tissues is True."""
+
+    refine_skull_intensity: Annotated[
+        bool,
+        OpenLIFUFieldData(
+            "Refine skull with intensity",
+            "If True, refine the EDT skull shell using Otsu intensity thresholding "
+            "to separate dark bone from bright soft tissue within the shell. "
+            "Morphological closing bridges the diploe gap, and only the largest "
+            "connected component is retained. Non-bone shell voxels sufficiently "
+            "far from the surface are reclassified as brain tissue.",
+        ),
+    ] = True
+    """If True, refine the skull shell by applying Otsu thresholding to
+    separate dark bone voxels from bright soft tissue within the EDT erosion
+    shell. Morphological closing bridges the diploe gap (bright marrow between
+    inner and outer cortical tables), and only the largest connected component
+    is retained. Non-bone shell voxels that are interior enough are reclassified
+    as brain tissue."""
+
+    def __post_init__(self) -> None:
+        # Let the base class normalize materials=None -> MATERIALS.copy()
+        # before we attempt the auto-swap.
+        super().__post_init__()
+
+        # If brain classification is enabled and the materials dict has
+        # "tissue" but not the classified keys, copy the dict (to avoid
+        # mutating a caller-owned object) and swap tissue for the three
+        # brain subtypes. This preserves user customizations to other
+        # materials (e.g., custom skull or water properties).
+        if self.classify_brain_tissues and "tissue" in self.materials and "csf" not in self.materials:
+            self.materials = dict(self.materials)
+            self.materials.pop("tissue")
+            self.materials.setdefault("csf", CSF)
+            self.materials.setdefault("gray_matter", GRAY_MATTER)
+            self.materials.setdefault("white_matter", WHITE_MATTER)
+            if self.ref_material not in self.materials:
+                msg = (
+                    f"ref_material '{self.ref_material}' was removed during "
+                    f"brain tissue auto-swap. Use 'water' or another key in "
+                    f"{set(self.materials.keys())}."
+                )
+                raise ValueError(msg)
+
+        if self.skull_thickness_mm < 0:
+            msg = f"skull_thickness_mm must be non-negative, got {self.skull_thickness_mm}."
+            raise ValueError(msg)
+        if not 0 <= self.air_threshold_quantile <= 1:
+            msg = f"air_threshold_quantile must be between 0 and 1, got {self.air_threshold_quantile}."
+            raise ValueError(msg)
+        if self.bias_correction_sigma_mm < 0:
+            msg = f"bias_correction_sigma_mm must be non-negative, got {self.bias_correction_sigma_mm}."
+            raise ValueError(msg)
+        if self.spatial_sigma_mm < 0:
+            msg = f"spatial_sigma_mm must be non-negative, got {self.spatial_sigma_mm}."
+            raise ValueError(msg)
+        if self.mrf_beta < 0:
+            msg = f"mrf_beta must be non-negative, got {self.mrf_beta}."
+            raise ValueError(msg)
+        if self.brain_extraction_margin_mm < 0:
+            msg = f"brain_extraction_margin_mm must be non-negative, got {self.brain_extraction_margin_mm}."
+            raise ValueError(msg)
+
+        required = _BASE_MATERIAL_KEYS | (
+            _BRAIN_CLASSIFIED_KEYS if self.classify_brain_tissues else _BRAIN_UNIFORM_KEYS
+        )
+        missing = required - set(self.materials.keys())
+        if missing:
+            msg = f"ThresholdMRI requires material keys {required}, missing: {missing}."
+            raise ValueError(msg)
+
+    def _segment(self, volume: xa.DataArray) -> xa.DataArray:
+        """Segment an MRI volume into tissue regions.
+
+        :param volume: An xarray DataArray containing the MRI volume data
+        :returns: An xarray DataArray with integer labels matching the ordering
+            from ``self._material_indices()``
+        """
+        data: np.ndarray = volume.to_numpy()
+        material_idx = self._material_indices()
+        water_label = material_idx["water"]
+
+        # Replace NaN values with 0 to avoid crashes in thresholding and
+        # connected-component analysis within compute_foreground_mask().
+        # Only copy the array if modification is actually needed.
+        has_nan = np.isnan(data).any()
+        if has_nan:
+            data = data.copy()
+            nan_count = int(np.isnan(data).sum())
+            logging.warning(
+                f"Volume contains {nan_count} NaN voxels; "
+                "replacing with 0 for segmentation.",
+            )
+            data[np.isnan(data)] = 0.0
+
+        # Each axis must have at least 2 coordinates for spacing computation.
+        for dim in volume.dims:
+            if len(volume.coords[dim]) < 2:
+                msg = (
+                    f"Axis '{dim}' has fewer than 2 coordinates; "
+                    "cannot compute voxel spacing for segmentation."
+                )
+                raise ValueError(msg)
+        # Extract voxel spacing from the first coordinate interval per axis.
+        # Assumes uniform spacing along each dimension.
+        spacing = np.array([
+            float(np.abs(volume.coords[dim].to_numpy()[1] - volume.coords[dim].to_numpy()[0]))
+            for dim in volume.dims
+        ])
+
+        # Step 1: Compute foreground (head) mask.
+        # If the volume has no intensity variation (e.g. all zeros or uniform),
+        # Otsu thresholding will fail. Return all-water in that case.
+        if float(data.max() - data.min()) == 0:
+            seg = np.full(data.shape, water_label, dtype=int)
+            return xa.DataArray(seg, coords=volume.coords, dims=volume.dims)
+
+        # compute_foreground_mask uses Otsu thresholding and connected-component
+        # analysis. It can raise ValueError (from threshold_otsu on degenerate
+        # histograms) or IndexError (from regionprops on empty label maps) in
+        # edge cases not caught by the intensity range check above.
+        try:
+            foreground: np.ndarray = compute_foreground_mask(data)
+        except (ValueError, IndexError):
+            logging.warning(
+                "Foreground mask computation failed; returning all-water segmentation.",
+            )
+            seg = np.full(data.shape, water_label, dtype=int)
+            return xa.DataArray(seg, coords=volume.coords, dims=volume.dims)
+
+        # Step 2: Determine effective skull thickness.
+        # Detect skull-stripped input: if foreground covers most of the
+        # non-zero voxels (ratio > 0.80), the volume is likely skull-stripped
+        # (brain only, no skull). In that case, override skull thickness to 0
+        # to avoid mislabeling cortical gray matter as skull. This heuristic
+        # has a wide margin: skull-stripped data clusters at ratio ~1.0 while
+        # whole-head data is below 0.50.
+        effective_skull_mm = self.skull_thickness_mm
+        nonzero_count = int(np.sum(data > 0))
+        foreground_count_check = int(np.sum(foreground))
+        if (
+            effective_skull_mm > 0
+            and nonzero_count > 0
+            and foreground_count_check / nonzero_count > 0.80
+            and data.size > 1000000  # skip heuristic on small/synthetic volumes
+        ):
+            logging.warning(
+                "Input appears to be skull-stripped (foreground covers "
+                f"{foreground_count_check / nonzero_count:.0%} of non-zero voxels). "
+                "Overriding skull_thickness_mm to 0.",
+            )
+            effective_skull_mm = 0.0
+
+        # Erode the foreground inward by effective_skull_mm to get brain interior.
+        # distance_transform_edt computes the distance of each foreground voxel
+        # to the nearest background voxel, accounting for anisotropic spacing.
+        foreground_dist: np.ndarray = distance_transform_edt(foreground, sampling=spacing)
+        brain_mask: np.ndarray = foreground_dist > effective_skull_mm
+
+        # Warn if the brain mask is suspiciously small.
+        foreground_count = int(np.sum(foreground))
+        brain_count = int(np.sum(brain_mask))
+        if foreground_count > 0 and brain_count < 0.1 * foreground_count:
+            logging.warning(
+                f"Brain mask contains fewer than 10% of foreground voxels "
+                f"({brain_count} / {foreground_count}). "
+                f"The skull_thickness_mm value ({self.skull_thickness_mm:.1f}) may be too large.",
+            )
+
+        # Step 3: Skull shell = foreground AND NOT brain interior.
+        skull_mask: np.ndarray = foreground & ~brain_mask
+
+        # Step 3b: Intensity-based skull refinement within the shell.
+        if self.refine_skull_intensity and effective_skull_mm > 0:
+            skull_mask, brain_mask = self._refine_skull_shell(
+                data, skull_mask, brain_mask, foreground, foreground_dist, effective_skull_mm,
+            )
+
+        # Step 4: Detect air cavities within the brain interior.
+        # Air cavities (sinuses, mastoid air cells) are near-zero intensity
+        # on T1, whereas CSF is dark but retains meaningful signal. We use
+        # a dual condition: a voxel is classified as air only if its
+        # intensity is below the quantile threshold AND below 10% of the
+        # median brain intensity. This prevents CSF from being mislabeled.
+        brain_intensities = data[brain_mask]
+        if brain_intensities.size > 0:
+            air_threshold = float(np.quantile(brain_intensities, self.air_threshold_quantile))
+            median_brain = float(np.median(brain_intensities))
+            absolute_ceiling = 0.10 * median_brain
+            effective_air_threshold = min(air_threshold, absolute_ceiling)
+            air_mask: np.ndarray = brain_mask & (data < effective_air_threshold)
+        else:
+            air_mask = np.zeros_like(brain_mask)
+
+        # The "parenchyma" mask is the brain interior minus air cavities.
+        parenchyma_mask: np.ndarray = brain_mask & ~air_mask
+
+        # Step 5: Assemble the label volume.
+        seg = np.full(data.shape, material_idx["water"], dtype=int)
+        seg[skull_mask] = material_idx["skull"]
+        seg[air_mask] = material_idx["air"]
+
+        if self.classify_brain_tissues:
+            # Compute a tighter mask for GMM classification that excludes
+            # boundary tissues (dura, meninges) just inside the skull.
+            if self.brain_extraction_margin_mm > 0:
+                gmm_brain_mask: np.ndarray = foreground_dist > (effective_skull_mm + self.brain_extraction_margin_mm)
+                gmm_parenchyma_mask: np.ndarray = gmm_brain_mask & ~air_mask
+            else:
+                gmm_parenchyma_mask = parenchyma_mask
+            self._classify_brain(data, gmm_parenchyma_mask, parenchyma_mask, seg, material_idx, spacing)
+        else:
+            seg[parenchyma_mask] = material_idx["tissue"]
+
+        return xa.DataArray(seg, coords=volume.coords, dims=volume.dims)
+
+    @staticmethod
+    def _refine_skull_shell(
+        data: np.ndarray,
+        skull_mask: np.ndarray,
+        brain_mask: np.ndarray,
+        foreground: np.ndarray,
+        foreground_dist: np.ndarray,
+        effective_skull_mm: float,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Refine the EDT skull shell using intensity thresholding.
+
+        The raw EDT shell includes scalp soft tissue (bright on T1) along
+        with actual bone (dark on T1). Otsu thresholding separates them,
+        morphological closing bridges the diploe gap, and keeping only the
+        largest connected component removes noise.
+
+        Returns the (possibly updated) skull_mask and brain_mask. If the
+        shell lacks sufficient intensity variation or bimodality, the
+        original masks are returned unchanged.
+
+        :param data: Raw MRI intensity array.
+        :param skull_mask: Binary skull shell from EDT erosion.
+        :param brain_mask: Binary brain interior mask.
+        :param foreground: Binary foreground mask.
+        :param foreground_dist: EDT distance from foreground boundary (mm).
+        :param effective_skull_mm: Skull thickness used for erosion.
+        :returns: Tuple of (refined_skull_mask, refined_brain_mask).
+        """
+        shell_mask = foreground & ~brain_mask
+        shell_intensities = data[shell_mask]
+        if shell_intensities.size <= 100:
+            return skull_mask, brain_mask
+
+        import skimage.filters
+        from scipy.ndimage import binary_closing
+        from scipy.ndimage import label as ndlabel
+
+        # Only refine if the shell has meaningful intensity variation.
+        # On uniform/synthetic data (CV < 0.1), Otsu cannot distinguish
+        # bone from soft tissue, so return unchanged.
+        nonzero_shell = shell_intensities[shell_intensities > 0]
+        shell_mean = float(np.mean(nonzero_shell)) if nonzero_shell.size > 0 else 0.0
+        shell_cv = (
+            float(np.std(nonzero_shell)) / shell_mean
+            if shell_mean > 0 and nonzero_shell.size > 100
+            else 0.0
+        )
+        if shell_cv <= 0.1:
+            return skull_mask, brain_mask
+
+        bone_threshold = skimage.filters.threshold_otsu(nonzero_shell)
+
+        # Skip refinement if Otsu splits the shell near 50/50, which
+        # indicates the shell lacks clear bimodality between bone (dark)
+        # and soft tissue (bright). A skewed split (e.g., 65/35) means
+        # one tissue type dominates and Otsu can separate them reliably.
+        below_frac = float(np.sum(nonzero_shell < bone_threshold)) / nonzero_shell.size
+        if abs(below_frac - 0.5) < 0.10:
+            return skull_mask, brain_mask
+
+        # Dark voxels in the shell are bone.
+        bone_mask = shell_mask & (data < bone_threshold)
+
+        # Light morphological closing (1 voxel) to connect fragmented
+        # cortical bone without re-adding soft tissue.
+        bone_mask = binary_closing(bone_mask, iterations=1)
+        bone_mask = bone_mask & shell_mask  # constrain back to shell
+
+        # Keep only the largest connected component.
+        labeled_arr, n_features = ndlabel(bone_mask)
+        if n_features > 0:
+            sizes = np.bincount(labeled_arr.ravel())[1:]
+            bone_mask = labeled_arr == (np.argmax(sizes) + 1)
+
+        # Reclassify non-bone shell voxels: those far enough from
+        # the outer surface (more than 30% of shell thickness into the
+        # head) are likely brain-adjacent tissue, so add them to brain.
+        # Closer to the surface stays water (scalp).
+        shell_not_bone = shell_mask & ~bone_mask
+        brain_mask = brain_mask | (
+            shell_not_bone & (foreground_dist > effective_skull_mm * 0.3)
+        )
+
+        return bone_mask, brain_mask
+
+    def _correct_bias_field(
+        self,
+        data: np.ndarray,
+        mask: np.ndarray,
+        spacing: np.ndarray,
+    ) -> np.ndarray:
+        """Apply bias field correction and intensity normalization.
+
+        Uses N4BiasFieldCorrection (SimpleITK) if available, otherwise falls
+        back to homomorphic correction via Gaussian smoothing in log space.
+        After bias correction, normalizes intensities within the mask to
+        [0, 1] using robust percentile scaling so that multi-Otsu thresholds
+        are consistent across scanners, protocols, and intensity scales.
+
+        :param data: The MRI intensity array
+        :param mask: Boolean mask of the region to correct (brain parenchyma)
+        :param spacing: Voxel spacing in mm per axis
+        :returns: Bias-corrected and intensity-normalized array
+        """
+        if self.use_n4:
+            try:
+                corrected = self._correct_bias_n4(data, mask, spacing)
+            except (ImportError, RuntimeError, OSError):
+                logging.warning(
+                    "N4 bias correction failed (SimpleITK may not be installed); "
+                    "falling back to homomorphic correction.",
+                )
+                corrected = self._correct_bias_homomorphic(data, mask, spacing)
+        else:
+            corrected = self._correct_bias_homomorphic(data, mask, spacing)
+
+        # Intensity normalization: rescale masked region to [0, 1] using
+        # robust percentile scaling. This makes multi-Otsu thresholds
+        # independent of the original intensity scale.
+        masked_vals = corrected[mask]
+        if masked_vals.size > 0:
+            vmin = float(np.percentile(masked_vals, 1))
+            vmax = float(np.percentile(masked_vals, 99))
+            if vmax > vmin:
+                corrected[mask] = np.clip(
+                    (corrected[mask] - vmin) / (vmax - vmin), 0, 1
+                )
+
+        return corrected
+
+    def _correct_bias_n4(
+        self,
+        data: np.ndarray,
+        mask: np.ndarray,
+        spacing: np.ndarray,
+    ) -> np.ndarray:
+        """N4 bias field correction via SimpleITK.
+
+        Fits the bias field on a downsampled (shrink_factor=4) version of
+        the image for speed, then reconstructs the full-resolution log bias
+        field and applies the correction at the original resolution.  Uses
+        4 fitting levels with 50 iterations each for robust convergence.
+
+        :param data: The MRI intensity array
+        :param mask: Boolean mask of the region to correct
+        :param spacing: Voxel spacing in mm per axis
+        :returns: Bias-corrected intensity array
+        :raises ImportError: If SimpleITK is not installed
+        :raises RuntimeError: If N4 correction fails
+        """
+        import SimpleITK as sitk  # pylint: disable=import-error
+
+        image = sitk.GetImageFromArray(data.astype(np.float32))
+        image.SetSpacing([float(s) for s in reversed(spacing)])
+        mask_image = sitk.GetImageFromArray(mask.astype(np.uint8))
+        mask_image.SetSpacing(image.GetSpacing())
+
+        # Downsample for faster bias field estimation.
+        shrink_factor = 4
+        # Clamp shrink factor so no axis shrinks below 1 voxel.
+        clamped = [min(shrink_factor, sz) for sz in image.GetSize()]
+        shrunk_image = sitk.Shrink(image, clamped)
+        shrunk_mask = sitk.Shrink(mask_image, clamped)
+
+        corrector = sitk.N4BiasFieldCorrectionImageFilter()
+        corrector.SetMaximumNumberOfIterations([50, 50, 50, 50])
+        corrector.SetConvergenceThreshold(0.001)
+        corrector.Execute(shrunk_image, shrunk_mask)
+
+        # Reconstruct the log bias field at original resolution and apply.
+        log_bias = corrector.GetLogBiasFieldAsImage(image)
+        corrected = image / sitk.Exp(log_bias)
+
+        return sitk.GetArrayFromImage(corrected).astype(np.float64)
+
+    def _correct_bias_homomorphic(
+        self,
+        data: np.ndarray,
+        mask: np.ndarray,
+        spacing: np.ndarray,
+    ) -> np.ndarray:
+        """Homomorphic bias field correction using Gaussian smoothing.
+
+        Fallback when SimpleITK is not available. Estimates the bias field
+        as a heavily smoothed version of the log-transformed image, then
+        divides it out.
+
+        :param data: The MRI intensity array
+        :param mask: Boolean mask of the region to correct
+        :param spacing: Voxel spacing in mm per axis
+        :returns: Bias-corrected intensity array
+        """
+        sigma_voxels = self.bias_correction_sigma_mm / spacing
+
+        masked_data = np.where(mask, np.clip(data, 0, None), 0.0)
+        log_data = np.log1p(masked_data)
+
+        mask_float = mask.astype(np.float64)
+        smoothed_log = gaussian_filter(log_data * mask_float, sigma=sigma_voxels)
+        smoothed_mask = gaussian_filter(mask_float, sigma=sigma_voxels)
+
+        safe_mask = smoothed_mask > 1e-6
+        bias_field = np.zeros_like(log_data)
+        bias_field[safe_mask] = smoothed_log[safe_mask] / smoothed_mask[safe_mask]
+
+        corrected = np.zeros_like(data)
+        corrected[mask] = np.expm1(log_data[mask] - bias_field[mask])
+
+        return corrected
+
+    @staticmethod
+    def _fit_gmm_1d(
+        values: np.ndarray,
+        n_components: int = 3,
+        max_iter: int = 50,
+        tol: float = 1e-6,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Fit a 1D Gaussian Mixture Model via Expectation-Maximization.
+
+        Uses only numpy (no scipy dependency in the inner loop). Initializes
+        component means from evenly-spaced quantiles of the data.
+
+        For large arrays (> 50,000 elements), the EM iterations are run on a
+        random subsample of 50,000 values for speed. The fitted parameters
+        are nearly identical to those from the full array and are returned
+        for posterior computation on the full dataset by the caller.
+
+        :param values: 1-D array of observed values
+        :param n_components: Number of Gaussian components
+        :param max_iter: Maximum EM iterations
+        :param tol: Convergence threshold on mean change (L-inf norm)
+        :returns: Tuple of (means, stds, weights), each of shape (n_components,),
+            sorted by ascending mean
+        """
+        # Subsample for EM if the array is large. Quantile initialization
+        # uses the full array so that tail components (e.g. CSF) are
+        # captured, but the iterative EM loop runs on the subsample.
+        _GMM_SUBSAMPLE_SIZE = 50_000
+        n_full = len(values)
+        quantiles = np.linspace(0.1, 0.9, n_components)
+        means = np.array([float(np.quantile(values, q)) for q in quantiles])
+
+        if n_full > _GMM_SUBSAMPLE_SIZE:
+            rng = np.random.default_rng(seed=42)
+            fit_values = rng.choice(values, size=_GMM_SUBSAMPLE_SIZE, replace=False)
+        else:
+            fit_values = values
+        n = len(fit_values)
+
+        # If any initial means are identical (common with discrete or
+        # heavily skewed data), spread them apart using the data range
+        # so that EM can discover distinct modes.
+        data_range = float(np.ptp(values))
+        if data_range > 0:
+            for i in range(1, n_components):
+                if means[i] <= means[i - 1]:
+                    means[i] = means[i - 1] + data_range * 0.01
+
+        # Initialize stds as a fraction of the data standard deviation.
+        data_std = float(np.std(values))
+        stds = np.full(n_components, max(data_std / n_components, 1e-10))
+
+        # Equal initial weights.
+        weights = np.full(n_components, 1.0 / n_components)
+
+        # Precompute constant for inline logpdf.
+        _LOG_2PI_HALF = 0.5 * np.log(2.0 * np.pi)
+
+        for _ in range(max_iter):
+            # E-step: compute posterior responsibilities (vectorized across
+            # all components in a single broadcast operation).
+            safe_stds = np.maximum(stds, 1e-10)
+            # shapes: means[:,None] = (K,1), fit_values[None,:] = (1,N)
+            z = (fit_values[None, :] - means[:, None]) / safe_stds[:, None]
+            log_resp = (
+                -0.5 * z * z
+                - np.log(safe_stds[:, None])
+                - _LOG_2PI_HALF
+                + np.log(weights[:, None] + 1e-300)
+            )
+
+            # Log-sum-exp for numerical stability.
+            log_resp_max = np.max(log_resp, axis=0)
+            log_norm = log_resp_max + np.log(
+                np.sum(np.exp(log_resp - log_resp_max), axis=0)
+            )
+            log_resp -= log_norm
+            resp = np.exp(log_resp)
+
+            # M-step: update parameters.
+            prev_means = means.copy()
+            for k in range(n_components):
+                nk = np.sum(resp[k])
+                if nk < 1e-10:
+                    continue
+                means[k] = np.dot(resp[k], fit_values) / nk
+                diff = fit_values - means[k]
+                stds[k] = np.sqrt(np.dot(resp[k], diff * diff) / nk)
+                stds[k] = max(stds[k], 1e-10)
+                weights[k] = nk / n
+
+            # Check convergence.
+            if np.max(np.abs(means - prev_means)) < tol:
+                break
+
+        # Sort components by ascending mean.
+        order = np.argsort(means)
+        return means[order], stds[order], weights[order]
+
+    @staticmethod
+    def _icm_iteration(
+        seg_arr: np.ndarray,
+        log_likelihoods: np.ndarray,
+        parenchyma_mask: np.ndarray,
+        label_indices: list[int],
+        beta: float,
+    ) -> np.ndarray:
+        """One pass of Iterated Conditional Modes (ICM) for MRF regularization.
+
+        For each voxel in the parenchyma mask, computes a posterior that
+        combines the GMM log-likelihood with a spatial prior that counts
+        how many of the 6-connected (face) neighbors share the same label.
+        The voxel is assigned to the class that maximizes this posterior.
+
+        Uses vectorized numpy operations (np.roll along each axis) rather
+        than per-voxel loops for performance.
+
+        :param seg_arr: Current integer label array (modified in-place)
+        :param log_likelihoods: Log-likelihood for each class, shape (n_classes, *vol_shape)
+        :param parenchyma_mask: Boolean mask restricting ICM updates
+        :param label_indices: Integer label values for each class (same order as log_likelihoods)
+        :param beta: MRF regularization strength
+        :returns: Updated seg_arr (same object, modified in-place)
+        """
+        n_classes = log_likelihoods.shape[0]
+
+        # For each class k, count how many of the 6 face-neighbors share
+        # label k. np.roll wraps at boundaries, but boundary voxels are
+        # typically outside the parenchyma mask and do not affect the result.
+        neighbor_agreement = np.zeros(
+            (n_classes, *seg_arr.shape), dtype=np.float32
+        )
+        for k, label_val in enumerate(label_indices):
+            same_label = (seg_arr == label_val).astype(np.float32)
+            agreement = np.zeros_like(same_label)
+            for axis in range(3):
+                agreement += np.roll(same_label, 1, axis=axis)
+                agreement += np.roll(same_label, -1, axis=axis)
+            neighbor_agreement[k] = agreement  # Range 0..6
+
+        # Posterior = log_likelihood + beta * neighbor_agreement.
+        # Higher agreement means more neighbors share this label, which is
+        # rewarded. This is equivalent to penalizing disagreement.
+        posterior = log_likelihoods + beta * neighbor_agreement
+
+        # Assign each voxel to the class with the highest posterior.
+        best_class = np.argmax(posterior, axis=0)
+        for k, label_val in enumerate(label_indices):
+            seg_arr[parenchyma_mask & (best_class == k)] = label_val
+
+        return seg_arr
+
+    def _classify_brain(
+        self,
+        data: np.ndarray,
+        gmm_parenchyma_mask: np.ndarray,
+        full_parenchyma_mask: np.ndarray,
+        seg: np.ndarray,
+        material_idx: dict[str, int],
+        spacing: np.ndarray,
+    ) -> None:
+        """Classify brain parenchyma voxels into CSF, gray matter, and white matter.
+
+        Modifies ``seg`` in-place. Optionally applies bias field correction,
+        then fits a 3-component Gaussian Mixture Model (EM-GMM) to the
+        (possibly tighter) GMM parenchyma mask. Posterior probability maps are
+        spatially smoothed with a Gaussian kernel for regularization, and the
+        process is iterated twice to refine the classification.
+
+        After GMM classification within the tight mask, labels are expanded
+        to cover the full parenchyma mask via nearest-neighbor assignment
+        using the Euclidean distance transform.
+
+        On T1-weighted MRI the component ordering (by mean) is:
+        CSF (dark) < gray matter (medium) < white matter (bright).
+
+        If the GMM fit fails (e.g. too few parenchyma voxels or degenerate
+        distribution), all parenchyma voxels fall back to the gray_matter label.
+
+        :param data: The (possibly NaN-cleaned) MRI intensity array
+        :param gmm_parenchyma_mask: Tight boolean mask for GMM fitting (may exclude boundary tissues)
+        :param full_parenchyma_mask: Full brain parenchyma mask for final label assignment
+        :param seg: Integer label array to modify in-place
+        :param material_idx: Mapping from material name to integer label
+        :param spacing: Voxel spacing in mm per axis
+        """
+        if int(np.sum(gmm_parenchyma_mask)) < 10:
+            # Too few voxels for meaningful classification.
+            seg[full_parenchyma_mask] = material_idx["gray_matter"]
+            return
+
+        # Apply bias field correction if enabled.
+        if self.bias_correction_sigma_mm > 0:
+            classify_data = self._correct_bias_field(data, gmm_parenchyma_mask, spacing)
+        else:
+            classify_data = data
+
+        try:
+            self._classify_brain_gmm(
+                classify_data, gmm_parenchyma_mask, seg, material_idx, spacing
+            )
+        except (RuntimeError, ValueError, np.linalg.LinAlgError):
+            logging.warning(
+                "EM-GMM brain tissue classification failed; "
+                "labeling all brain parenchyma as gray matter.",
+            )
+            seg[full_parenchyma_mask] = material_idx["gray_matter"]
+            return
+
+        # Expand GMM labels from the tight mask to the full parenchyma mask
+        # using nearest-neighbor assignment via the distance transform.
+        gap_mask = full_parenchyma_mask & ~gmm_parenchyma_mask
+        if np.any(gap_mask):
+            # distance_transform_edt with return_indices gives the coordinates
+            # of the nearest labeled (non-zero in the seed) voxel for each
+            # background voxel. We seed with the GMM-classified region.
+            seed = gmm_parenchyma_mask.astype(np.uint8)
+            _, nearest_indices = distance_transform_edt(
+                seed == 0, sampling=spacing, return_indices=True
+            )
+            # Copy labels from the nearest GMM-classified voxel into the gap.
+            seg[gap_mask] = seg[tuple(nearest_indices[:, gap_mask])]
+
+    def _classify_brain_gmm(
+        self,
+        classify_data: np.ndarray,
+        parenchyma_mask: np.ndarray,
+        seg: np.ndarray,
+        material_idx: dict[str, int],
+        spacing: np.ndarray,
+    ) -> None:
+        """Core GMM classification with spatial regularization.
+
+        Fits a 3-component GMM, computes full-volume log-likelihood maps,
+        then applies spatial regularization. When ``mrf_beta > 0``, uses
+        Markov Random Field regularization via Iterated Conditional Modes
+        (ICM), which penalizes label disagreement among 6-connected
+        neighbors while preserving tissue boundaries. When ``mrf_beta == 0``
+        and ``spatial_sigma_mm > 0``, falls back to Gaussian smoothing of
+        posterior probability maps. The outer loop iterates twice: after
+        each regularization pass, GMM parameters are re-estimated from the
+        current labels/posteriors.
+
+        Called by ``_classify_brain``; raises on failure so the caller can
+        apply the gray-matter fallback.
+
+        :param classify_data: Bias-corrected (or raw) intensity array
+        :param parenchyma_mask: Boolean mask of brain parenchyma
+        :param seg: Integer label array to modify in-place
+        :param material_idx: Mapping from material name to integer label
+        :param spacing: Voxel spacing in mm per axis
+        """
+        use_mrf = self.mrf_beta > 0
+        sigma_voxels = self.spatial_sigma_mm / spacing
+        label_keys = ["csf", "gray_matter", "white_matter"]  # sorted by T1 mean
+        label_indices = [material_idx[k] for k in label_keys]
+        n_components = len(label_keys)
+        n_outer = 2  # total spatial-regularization iterations
+        n_icm = 5  # ICM iterations per outer loop (when using MRF)
+
+        # Extract parenchyma intensities for the initial fit.
+        parenchyma_vals = classify_data[parenchyma_mask]
+
+        # Initial GMM fit on raw parenchyma intensities.
+        means, stds, weights = self._fit_gmm_1d(
+            parenchyma_vals, n_components=n_components
+        )
+
+        # Precompute constant for inline logpdf (avoids scipy overhead).
+        _LOG_2PI_HALF = 0.5 * np.log(2.0 * np.pi)
+
+        # Determine whether we need full 3D probability maps.
+        # MRF needs 3D log-likelihoods for ICM; Gaussian smoothing needs 3D
+        # prob_maps for the convolution. When neither is active, we can
+        # compute likelihoods only at parenchyma voxels (flat arrays).
+        needs_3d = use_mrf or self.spatial_sigma_mm > 0
+
+        for _iteration in range(n_outer):
+            safe_stds = np.maximum(stds, 1e-10)
+            log_weights = np.log(weights + 1e-300)
+
+            if needs_3d:
+                # Build full-volume log-likelihood maps (only inside parenchyma).
+                log_likelihoods = np.full(
+                    (n_components, *classify_data.shape), -np.inf, dtype=np.float64
+                )
+                prob_maps = np.zeros(
+                    (n_components, *classify_data.shape), dtype=np.float64
+                )
+                for k in range(n_components):
+                    z = (classify_data - means[k]) / safe_stds[k]
+                    log_prob = (
+                        -0.5 * z * z
+                        - np.log(safe_stds[k])
+                        - _LOG_2PI_HALF
+                        + log_weights[k]
+                    )
+                    log_likelihoods[k][parenchyma_mask] = log_prob[parenchyma_mask]
+                    prob_maps[k] = np.exp(log_prob)
+                    # Zero out non-parenchyma to avoid leakage.
+                    prob_maps[k][~parenchyma_mask] = 0.0
+            else:
+                # Fast path: compute likelihoods only at parenchyma voxels.
+                # shapes: parenchyma_vals = (M,), means = (K,)
+                z_flat = (parenchyma_vals[None, :] - means[:, None]) / safe_stds[:, None]
+                log_ll_flat = (
+                    -0.5 * z_flat * z_flat
+                    - np.log(safe_stds[:, None])
+                    - _LOG_2PI_HALF
+                    + log_weights[:, None]
+                )
+                prob_flat = np.exp(log_ll_flat)
+
+            if use_mrf:
+                # MRF regularization via ICM.
+                # Initialize seg labels from the argmax of the raw likelihoods
+                # (only within the parenchyma mask) before ICM iterations.
+                init_labels = np.argmax(
+                    log_likelihoods[:, parenchyma_mask], axis=0
+                )
+                for k, label_val in enumerate(label_indices):
+                    mask_k = parenchyma_mask.copy()
+                    mask_k[parenchyma_mask] = init_labels == k
+                    seg[mask_k] = label_val
+
+                # Run ICM iterations to refine labels using spatial context.
+                for _icm_iter in range(n_icm):
+                    self._icm_iteration(
+                        seg, log_likelihoods, parenchyma_mask,
+                        label_indices, self.mrf_beta,
+                    )
+
+                # Build soft responsibilities from the final labels for
+                # GMM re-estimation. Use the normalized likelihoods (posteriors)
+                # so the M-step is consistent with the E-step.
+                prob_sum = np.sum(prob_maps, axis=0)
+                prob_sum[prob_sum < 1e-300] = 1e-300
+                for k in range(n_components):
+                    prob_maps[k] /= prob_sum
+
+                # Extract labels from seg for final output.
+                labels_3d = np.zeros(int(np.sum(parenchyma_mask)), dtype=int)
+                for k, label_val in enumerate(label_indices):
+                    labels_3d[seg[parenchyma_mask] == label_val] = k
+
+            elif self.spatial_sigma_mm > 0:
+                # Gaussian smoothing regularization path.
+                mask_float = parenchyma_mask.astype(np.float64)
+                smoothed_mask = gaussian_filter(mask_float, sigma=sigma_voxels)
+                safe = parenchyma_mask & (smoothed_mask > 1e-6)
+                for k in range(n_components):
+                    smoothed_prob = gaussian_filter(
+                        prob_maps[k] * mask_float, sigma=sigma_voxels
+                    )
+                    result = np.zeros_like(prob_maps[k])
+                    result[safe] = smoothed_prob[safe] / smoothed_mask[safe]
+                    prob_maps[k] = result
+
+                # Normalize posteriors within parenchyma.
+                prob_sum = np.sum(prob_maps, axis=0)
+                prob_sum[prob_sum < 1e-300] = 1e-300
+                for k in range(n_components):
+                    prob_maps[k] /= prob_sum
+
+                # Assign labels via argmax of smoothed posteriors.
+                labels_3d = np.argmax(prob_maps[:, parenchyma_mask], axis=0)
+
+            else:
+                # No spatial regularization: work entirely with flat arrays.
+                # Normalize posteriors at parenchyma voxels only.
+                prob_sum_flat = np.sum(prob_flat, axis=0)
+                prob_sum_flat[prob_sum_flat < 1e-300] = 1e-300
+                for k in range(n_components):
+                    prob_flat[k] /= prob_sum_flat
+
+                # Assign labels via argmax of posteriors.
+                labels_3d = np.argmax(prob_flat, axis=0)
+
+            # Re-estimate GMM parameters from the current soft assignment
+            # (for the next iteration). Use the posteriors as weights.
+            parenchyma_intensities = classify_data[parenchyma_mask]
+            new_means = np.empty(n_components)
+            new_stds = np.empty(n_components)
+            new_weights = np.empty(n_components)
+            for k in range(n_components):
+                if needs_3d:
+                    resp_k = prob_maps[k][parenchyma_mask]
+                else:
+                    resp_k = prob_flat[k]
+                nk = np.sum(resp_k)
+                if nk < 1e-10:
+                    new_means[k] = means[k]
+                    new_stds[k] = stds[k]
+                    new_weights[k] = weights[k]
+                    continue
+                new_means[k] = np.dot(resp_k, parenchyma_intensities) / nk
+                diff = parenchyma_intensities - new_means[k]
+                new_stds[k] = np.sqrt(np.dot(resp_k, diff * diff) / nk)
+                new_stds[k] = max(new_stds[k], 1e-10)
+                new_weights[k] = nk / len(parenchyma_intensities)
+
+            means, stds, weights = new_means, new_stds, new_weights
+
+        # Write final labels into seg. Components are sorted by mean:
+        # index 0 = CSF (lowest), 1 = gray matter, 2 = white matter (highest).
+        for k, key in enumerate(label_keys):
+            voxel_mask = parenchyma_mask.copy()
+            voxel_mask[parenchyma_mask] = labels_3d == k
+            seg[voxel_mask] = material_idx[key]
+
+    def to_table(self) -> pd.DataFrame:
+        """
+        Get a table of the segmentation method parameters
+
+        :returns: Pandas DataFrame of the segmentation method parameters
+        """
+        records = [
+            {"Name": "Type", "Value": "Threshold MRI", "Unit": ""},
+            {"Name": "Skull Thickness", "Value": self.skull_thickness_mm, "Unit": "mm"},
+            {"Name": "Air Threshold Quantile", "Value": self.air_threshold_quantile, "Unit": ""},
+            {"Name": "Classify Brain Tissues", "Value": self.classify_brain_tissues, "Unit": ""},
+            {"Name": "Bias Correction Sigma", "Value": self.bias_correction_sigma_mm, "Unit": "mm"},
+            {"Name": "Use N4", "Value": self.use_n4, "Unit": ""},
+            {"Name": "Spatial Regularization Sigma", "Value": self.spatial_sigma_mm, "Unit": "mm"},
+            {"Name": "MRF Beta", "Value": self.mrf_beta, "Unit": ""},
+            {"Name": "Brain Extraction Margin", "Value": self.brain_extraction_margin_mm, "Unit": "mm"},
+            {"Name": "Refine Skull Intensity", "Value": self.refine_skull_intensity, "Unit": ""},
+            {"Name": "Reference Material", "Value": self.ref_material, "Unit": ""},
+        ]
+        return pd.DataFrame.from_records(records)

--- a/src/openlifu/seg/skinseg.py
+++ b/src/openlifu/seg/skinseg.py
@@ -22,7 +22,7 @@ import trimesh
 import vtk
 from packaging.version import parse
 from scipy.interpolate import LinearNDInterpolator
-from scipy.ndimage import distance_transform_edt
+from scipy.ndimage import binary_closing, generate_binary_structure
 from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
 
 from openlifu.geo import cartesian_to_spherical, spherical_to_cartesian_vectorized
@@ -96,17 +96,22 @@ def compute_foreground_mask(
     # step 3: do a morphological closing.
     # while this does fill some holes, that's not the main point since step 4 already fills holes.
     # the point of this step is rather to clean up and smooth out the skin surface of small cavities.
-    pad_width = int(closing_radius+2) # pad to avoid the situation where dilation hits the boundary
-    foreground_mask_padded = np.pad(foreground_mask, pad_width, mode='constant')
-    background_edt = distance_transform_edt(~foreground_mask_padded)
-    foreground_dilated = background_edt <= closing_radius
-    foreground_dilated_edt = distance_transform_edt(foreground_dilated)
-    foreground_closed = foreground_dilated_edt >= closing_radius
-
-    # crop to undo the padding above
-    h,w,d = foreground_mask.shape
-    p = pad_width
-    foreground_mask = foreground_closed[p:p+h,p:p+w,p:p+d]
+    # Uses binary_closing with a 6-connected structuring element iterated
+    # closing_radius times, which is much faster than the original two-pass
+    # EDT approach (~15x). The diamond-shaped kernel produces slightly
+    # different boundary voxels (<0.2%) versus the EDT's Euclidean ball,
+    # but this does not affect downstream segmentation quality.
+    closing_r = int(closing_radius)
+    if closing_r > 0:
+        pad_width = closing_r + 2
+        padded = np.pad(foreground_mask, pad_width, mode='constant')
+        struct = generate_binary_structure(3, 1)  # 6-connected
+        closed_padded = binary_closing(
+            padded.astype(np.uint8), structure=struct, iterations=closing_r
+        ).astype(bool)
+        h, w, d = foreground_mask.shape
+        p = pad_width
+        foreground_mask = closed_padded[p:p+h, p:p+w, p:p+d]
 
     # step 4: take the complement of the largest connected component of the current background.
     # the background mask at this point contains the "actual background" and possibly also some

--- a/src/openlifu/seg/skinseg.py
+++ b/src/openlifu/seg/skinseg.py
@@ -98,9 +98,7 @@ def compute_foreground_mask(
     # the point of this step is rather to clean up and smooth out the skin surface of small cavities.
     # Uses binary_closing with a 6-connected structuring element iterated
     # closing_radius times, which is much faster than the original two-pass
-    # EDT approach (~15x). The diamond-shaped kernel produces slightly
-    # different boundary voxels (<0.2%) versus the EDT's Euclidean ball,
-    # but this does not affect downstream segmentation quality.
+    # EDT approach (~15x).
     closing_r = int(closing_radius)
     if closing_r > 0:
         pad_width = closing_r + 2

--- a/src/openlifu/sim/kwave_if.py
+++ b/src/openlifu/sim/kwave_if.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from copy import deepcopy
 import pathlib
+from copy import deepcopy
 from typing import List
 
 import numpy as np

--- a/src/openlifu/sim/kwave_if.py
+++ b/src/openlifu/sim/kwave_if.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from copy import deepcopy
+import pathlib
 from typing import List
 
 import numpy as np
@@ -77,6 +79,99 @@ def get_source(kgrid, karray, source_sig):
     logging.info("Getting distributed source signal")
     source.p = karray.get_distributed_source_signal(kgrid, source_sig)
     return source
+
+def run_point_source_simulation(
+    params: xa.Dataset,
+    source_mask: np.ndarray,
+    sensor_mask: np.ndarray,
+    freq: float = 1e6,
+    n_cycles: int = 3,
+    sound_speed_ref: float = 1500.0,
+    cfl: float = 0.3,
+    gpu: bool = True,
+    ref_values_only: bool = False,
+):
+    """Run a k-wave simulation with a point source and sparse sensor mask.
+
+    Used by the SimulationCorrected delay method to implement the reciprocity
+    approach: a single point source is placed at the target and pressure time
+    series are recorded at transducer element positions.
+
+    :param params: Simulation grid dataset with sound_speed, density, attenuation.
+    :param source_mask: 3D binary array with 1 at the source (target) voxel.
+    :param sensor_mask: 3D binary array with 1s at sensor (element) voxels.
+    :param freq: Source frequency in Hz.
+    :param n_cycles: Number of cycles in the source pulse.
+    :param sound_speed_ref: Reference speed of sound (m/s) for time stepping.
+    :param cfl: Courant-Friedrichs-Lewy number for time stepping.
+    :param gpu: Whether to use GPU acceleration.
+    :param ref_values_only: If True, use reference (homogeneous) medium values.
+    :returns: Tuple of (sensor_data, dt) where sensor_data is a 2D array
+        (n_sensor_points, n_timesteps) and dt is the time step in seconds.
+    """
+    from kwave.ksensor import kSensor
+    from kwave.ksource import kSource
+    from kwave.kspaceFirstOrder3D import kspaceFirstOrder3D
+    from kwave.options.simulation_execution_options import SimulationExecutionOptions
+    from kwave.options.simulation_options import SimulationOptions
+
+    # Build kgrid
+    kgrid = get_kgrid(params.coords, sound_speed_ref=sound_speed_ref, cfl=cfl)
+    dt = float(kgrid.dt)
+
+    # Build medium
+    medium = get_medium(params, ref_values_only=ref_values_only)
+
+    # Build source: short sinusoidal burst at the target voxel
+    source = kSource()
+    source.p_mask = source_mask
+    t_sig = np.arange(0, n_cycles / freq, dt)
+    # Windowed tone burst: Hann window * sine
+    if len(t_sig) > 1:
+        window = np.hanning(len(t_sig))
+    else:
+        window = np.ones(len(t_sig))
+    source_signal = window * np.sin(2 * np.pi * freq * t_sig)
+    # kSource expects (n_source_points, n_timesteps) but for a single point
+    # source, a 1D signal is acceptable. Reshape to (1, N) to be safe.
+    source.p = source_signal.reshape(1, -1)
+
+    # Build sensor
+    sensor = kSensor(sensor_mask, record=['p'])
+
+    # Run simulation
+    logging.info("Running point source reciprocal simulation for delay correction")
+    simulation_options = SimulationOptions(
+        pml_auto=True,
+        pml_inside=False,
+        save_to_disk=True,
+        data_cast='single',
+    )
+    execution_options = SimulationExecutionOptions(is_gpu_simulation=gpu)
+    try:
+        output = kspaceFirstOrder3D(
+            kgrid=kgrid,
+            source=source,
+            sensor=sensor,
+            medium=medium,
+            simulation_options=simulation_options,
+            execution_options=execution_options,
+        )
+    finally:
+        # Clean up temporary H5 files left by k-wave (#435)
+        # Runs even if simulation raises, preventing temp file leaks.
+        for fpath in [simulation_options.input_filename, simulation_options.output_filename]:
+            with contextlib.suppress(OSError):
+                pathlib.Path(fpath).unlink(missing_ok=True)
+    logging.info("Point source reciprocal simulation complete")
+
+    # output['p'] has shape (n_sensor_points, n_timesteps)
+    sensor_data = output['p']
+    if sensor_data.ndim == 1:
+        sensor_data = sensor_data.reshape(1, -1)
+
+    return sensor_data, dt
+
 
 def run_simulation(arr: xdc.Transducer,
                    params: xa.Dataset,
@@ -192,8 +287,15 @@ def run_simulation(arr: xdc.Transducer,
     execution_options = SimulationExecutionOptions(is_gpu_simulation=gpu)
     inputs = {'kgrid':kgrid, 'source':source, 'sensor':sensor, 'medium':medium,
               'simulation_options':simulation_options, 'execution_options':execution_options}
-    output = kspaceFirstOrder3D(**deepcopy(inputs))
+    try:
+        output = kspaceFirstOrder3D(**deepcopy(inputs))
+    finally:
+        # Clean up temporary H5 files left by k-wave (#435)
+        for fpath in [simulation_options.input_filename, simulation_options.output_filename]:
+            with contextlib.suppress(OSError):
+                pathlib.Path(fpath).unlink(missing_ok=True)
     logging.info('Simulation Complete')
+
     sz = list(params.coords.sizes.values())
     ds_dict = {}
     for record in sensor.record:

--- a/tests/test_seg_method.py
+++ b/tests/test_seg_method.py
@@ -14,7 +14,7 @@ def example_seg_method() -> seg_methods.UniformSegmentation:
                 name="water",
                 sound_speed=1500.0,
                 density=1000.0,
-                attenuation=0.0,
+                attenuation=0.002,
                 specific_heat=4182.0,
                 thermal_conductivity=0.598
             ),
@@ -22,7 +22,7 @@ def example_seg_method() -> seg_methods.UniformSegmentation:
                 name="skull",
                 sound_speed=4080.0,
                 density=1900.0,
-                attenuation=0.0,
+                attenuation=8.0,
                 specific_heat=1100.0,
                 thermal_conductivity=0.3
             ),
@@ -45,7 +45,7 @@ def test_uniform_seg_method_no_reference_material():
                     name="water",
                     sound_speed=1500.0,
                     density=1000.0,
-                    attenuation=0.0,
+                    attenuation=0.002,
                     specific_heat=4182.0,
                     thermal_conductivity=0.598
                 ),
@@ -53,7 +53,7 @@ def test_uniform_seg_method_no_reference_material():
                     name="skull",
                     sound_speed=4080.0,
                     density=1900.0,
-                    attenuation=0.0,
+                    attenuation=8.0,
                     specific_heat=1100.0,
                     thermal_conductivity=0.3
                 ),

--- a/tests/test_simulation_corrected.py
+++ b/tests/test_simulation_corrected.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from openlifu.bf.delay_methods import DelayMethod, SimulationCorrected
+
+
+class TestSimulationCorrectedConstruction:
+    """Test basic construction of SimulationCorrected instances."""
+
+    def test_default_construction(self):
+        method = SimulationCorrected()
+        assert isinstance(method, SimulationCorrected)
+        assert isinstance(method, DelayMethod)
+        assert method.c0 == 1500.0
+        assert method.cfl == 0.3
+        assert method.n_cycles == 3
+        assert method.gpu is True
+
+    def test_custom_params(self):
+        method = SimulationCorrected(c0=1480.0, cfl=0.2, n_cycles=5, gpu=False)
+        assert method.c0 == 1480.0
+        assert method.cfl == 0.2
+        assert method.n_cycles == 5
+        assert method.gpu is False
+
+
+class TestSimulationCorrectedValidation:
+    """Test parameter validation."""
+
+    def test_invalid_c0_negative(self):
+        with pytest.raises(ValueError, match="greater than 0"):
+            SimulationCorrected(c0=-100.0)
+
+    def test_invalid_c0_zero(self):
+        with pytest.raises(ValueError, match="greater than 0"):
+            SimulationCorrected(c0=0.0)
+
+    def test_invalid_c0_type(self):
+        with pytest.raises(TypeError):
+            SimulationCorrected(c0="fast")
+
+    def test_invalid_cfl_too_high(self):
+        with pytest.raises(ValueError, match="between 0 and 1"):
+            SimulationCorrected(cfl=1.0)
+
+    def test_invalid_cfl_zero(self):
+        with pytest.raises(ValueError, match="between 0 and 1"):
+            SimulationCorrected(cfl=0.0)
+
+    def test_invalid_cfl_negative(self):
+        with pytest.raises(ValueError, match="between 0 and 1"):
+            SimulationCorrected(cfl=-0.1)
+
+    def test_invalid_n_cycles_zero(self):
+        with pytest.raises(ValueError, match="at least 1"):
+            SimulationCorrected(n_cycles=0)
+
+    def test_invalid_n_cycles_type(self):
+        with pytest.raises(TypeError):
+            SimulationCorrected(n_cycles=2.5)
+
+    def test_n_cycles_float_int_coercion(self):
+        # A float that is exactly an integer should be accepted
+        method = SimulationCorrected(n_cycles=3.0)
+        assert method.n_cycles == 3
+        assert isinstance(method.n_cycles, int)
+
+
+class TestSimulationCorrectedSerialization:
+    """Test to_dict / from_dict round-trip serialization."""
+
+    def test_to_dict(self):
+        method = SimulationCorrected(c0=1480.0, cfl=0.25, n_cycles=4, gpu=False)
+        d = method.to_dict()
+        assert d['class'] == 'SimulationCorrected'
+        assert d['c0'] == 1480.0
+        assert d['cfl'] == 0.25
+        assert d['n_cycles'] == 4
+        assert d['gpu'] is False
+
+    def test_from_dict(self):
+        d = {
+            'class': 'SimulationCorrected',
+            'c0': 1480.0,
+            'cfl': 0.25,
+            'n_cycles': 4,
+            'gpu': False,
+        }
+        method = DelayMethod.from_dict(d)
+        assert isinstance(method, SimulationCorrected)
+        assert method.c0 == 1480.0
+        assert method.cfl == 0.25
+        assert method.n_cycles == 4
+        assert method.gpu is False
+
+    def test_round_trip(self):
+        original = SimulationCorrected(c0=1450.0, cfl=0.35, n_cycles=5, gpu=True)
+        d = original.to_dict()
+        restored = DelayMethod.from_dict(d)
+        assert isinstance(restored, SimulationCorrected)
+        assert restored.c0 == original.c0
+        assert restored.cfl == original.cfl
+        assert restored.n_cycles == original.n_cycles
+        assert restored.gpu == original.gpu
+
+    def test_round_trip_defaults(self):
+        original = SimulationCorrected()
+        d = original.to_dict()
+        restored = DelayMethod.from_dict(d)
+        assert isinstance(restored, SimulationCorrected)
+        assert restored.c0 == original.c0
+        assert restored.cfl == original.cfl
+        assert restored.n_cycles == original.n_cycles
+        assert restored.gpu == original.gpu
+
+
+class TestSimulationCorrectedTable:
+    """Test the to_table method."""
+
+    def test_to_table(self):
+        method = SimulationCorrected()
+        table = method.to_table()
+        assert len(table) == 5
+        assert table.iloc[0]['Name'] == 'Type'
+        assert table.iloc[0]['Value'] == 'SimulationCorrected'
+        assert table.iloc[1]['Name'] == 'Default Sound Speed'
+        assert table.iloc[1]['Value'] == 1500.0

--- a/tests/test_simulation_corrected.py
+++ b/tests/test_simulation_corrected.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import numpy as np
 import pytest
 
 from openlifu.bf.delay_methods import DelayMethod, SimulationCorrected
@@ -126,3 +129,58 @@ class TestSimulationCorrectedTable:
         assert table.iloc[0]['Value'] == 'SimulationCorrected'
         assert table.iloc[1]['Name'] == 'Default Sound Speed'
         assert table.iloc[1]['Value'] == 1500.0
+
+
+class TestSimulationCorrectedBehavior:
+    """Test delay calculation logic by mocking the k-wave simulation layer."""
+
+    def test_delays_from_known_arrival_times(self):
+        """When _run_reciprocal_simulation returns known arrival times,
+        calc_delays should return max(arrival) - arrival for each element."""
+        arrival_times = np.array([0.001, 0.002, 0.003])
+        expected_delays = np.array([0.002, 0.001, 0.0])
+
+        method = SimulationCorrected()
+        with patch.object(
+            SimulationCorrected,
+            "_run_reciprocal_simulation",
+            return_value=arrival_times,
+        ), patch("importlib.util.find_spec", return_value=True):
+            delays = method.calc_delays(
+                arr=None, target=None, params=None, transform=None
+            )
+        np.testing.assert_allclose(delays, expected_delays)
+
+    def test_fallback_on_simulation_failure(self):
+        """When _run_reciprocal_simulation raises, calc_delays should
+        fall back to Direct geometric delays without crashing."""
+        method = SimulationCorrected()
+        with patch.object(
+            SimulationCorrected,
+            "_run_reciprocal_simulation",
+            side_effect=RuntimeError("mocked failure"),
+        ), patch("importlib.util.find_spec", return_value=True), patch.object(
+            SimulationCorrected,
+            "_fallback_delays",
+            return_value=np.array([0.0, 0.0, 0.0]),
+        ) as mock_fallback:
+            delays = method.calc_delays(
+                arr=None, target=None, params=None, transform=None
+            )
+        mock_fallback.assert_called_once()
+        np.testing.assert_array_equal(delays, [0.0, 0.0, 0.0])
+
+    def test_fallback_when_kwave_missing(self):
+        """When k-wave is not installed, calc_delays should fall back
+        to Direct geometric delays."""
+        method = SimulationCorrected()
+        with patch("importlib.util.find_spec", return_value=None), patch.object(
+            SimulationCorrected,
+            "_fallback_delays",
+            return_value=np.array([0.0, 0.0]),
+        ) as mock_fallback:
+            delays = method.calc_delays(
+                arr=None, target=None, params=None, transform=None
+            )
+        mock_fallback.assert_called_once()
+        np.testing.assert_array_equal(delays, [0.0, 0.0])

--- a/tests/test_threshold_mri.py
+++ b/tests/test_threshold_mri.py
@@ -289,6 +289,30 @@ def test_classify_brain_gmm_failure_fallback() -> None:
         assert set(np.unique(result.to_numpy()[brain_voxels])) == {idx["gray_matter"]}
 
 
+def test_classify_brain_degenerate_constant_intensity() -> None:
+    """When the brain interior has near-constant intensity, the GMM cannot
+    fit meaningful components. All brain voxels should fall back to
+    gray_matter rather than collapsing to CSF (argmax class 0)."""
+    volume = create_synthetic_head_volume(shape=(64, 64, 64), intensity=100.0)
+    seg = ThresholdMRI(
+        classify_brain_tissues=True,
+        air_threshold_quantile=0.0,
+        skull_thickness_mm=7.0,
+    )
+    result = seg._segment(volume)
+    idx = seg._material_indices()
+    brain_labels = {idx["csf"], idx["gray_matter"], idx["white_matter"]}
+    brain_voxels = np.isin(result.to_numpy(), list(brain_labels))
+    if np.any(brain_voxels):
+        unique_brain = set(np.unique(result.to_numpy()[brain_voxels]))
+        assert idx["gray_matter"] in unique_brain, (
+            "Degenerate GMM should fall back to gray_matter"
+        )
+        assert idx["csf"] not in unique_brain, (
+            "Degenerate GMM should not produce all-CSF labels"
+        )
+
+
 def test_gmm_preserves_natural_class_proportions() -> None:
     """EM-GMM should recover class proportions that reflect the actual geometry
     of the concentric spheres, NOT force them to ~33% each (as histogram

--- a/tests/test_threshold_mri.py
+++ b/tests/test_threshold_mri.py
@@ -298,6 +298,7 @@ def test_classify_brain_degenerate_constant_intensity() -> None:
         classify_brain_tissues=True,
         air_threshold_quantile=0.0,
         skull_thickness_mm=7.0,
+        bias_correction_sigma_mm=0.0,
     )
     result = seg._segment(volume)
     idx = seg._material_indices()

--- a/tests/test_threshold_mri.py
+++ b/tests/test_threshold_mri.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import xarray as xa
+
+from openlifu.seg import SegmentationMethod
+from openlifu.seg.material import MATERIALS, TISSUE, WATER, Material
+from openlifu.seg.seg_methods.threshold_mri import ThresholdMRI
+
+# --- Helpers ---
+
+def create_synthetic_head_volume(
+    shape: tuple[int, int, int] = (64, 64, 64),
+    spacing: float = 1.0,
+    head_radius: float = 25.0,
+    intensity: float = 100.0,
+) -> xa.DataArray:
+    """Sphere with given intensity inside, 0 outside, centered at origin."""
+    nz, ny, nx = shape
+    x = np.arange(nx) * spacing - (nx - 1) * spacing / 2
+    y = np.arange(ny) * spacing - (ny - 1) * spacing / 2
+    z = np.arange(nz) * spacing - (nz - 1) * spacing / 2
+    zz, yy, xx = np.meshgrid(z, y, x, indexing="ij")
+    dist = np.sqrt(xx**2 + yy**2 + zz**2)
+    data = np.where(dist <= head_radius, intensity, 0.0)
+    return xa.DataArray(data, dims=["z", "y", "x"], coords={"z": z, "y": y, "x": x})
+
+
+def create_three_tissue_sphere(
+    shape: tuple[int, int, int] = (64, 64, 64),
+    spacing: float = 1.0,
+    head_radius: float = 25.0,
+) -> xa.DataArray:
+    """Concentric spheres simulating T1 contrast: CSF=30, GM=70, WM=100."""
+    nz, ny, nx = shape
+    x = np.arange(nx) * spacing - (nx - 1) * spacing / 2
+    y = np.arange(ny) * spacing - (ny - 1) * spacing / 2
+    z = np.arange(nz) * spacing - (nz - 1) * spacing / 2
+    zz, yy, xx = np.meshgrid(z, y, x, indexing="ij")
+    dist = np.sqrt(xx**2 + yy**2 + zz**2)
+    data = np.zeros(shape)
+    data[dist <= head_radius] = 30.0
+    data[dist <= head_radius * 0.7] = 70.0
+    data[dist <= head_radius * 0.5] = 100.0
+    return xa.DataArray(data, dims=["z", "y", "x"], coords={"z": z, "y": y, "x": x})
+
+
+@pytest.fixture()
+def synthetic_sphere() -> xa.DataArray:
+    return create_synthetic_head_volume()
+
+
+# --- Serialization ---
+
+def test_dict_roundtrip_default() -> None:
+    seg = ThresholdMRI()
+    reconstructed = SegmentationMethod.from_dict(seg.to_dict())
+    assert isinstance(reconstructed, ThresholdMRI)
+    assert reconstructed == seg
+
+
+def test_dict_roundtrip_custom_params() -> None:
+    seg = ThresholdMRI(skull_thickness_mm=10.0, air_threshold_quantile=0.1)
+    reconstructed = SegmentationMethod.from_dict(seg.to_dict())
+    assert reconstructed.skull_thickness_mm == 10.0
+    assert reconstructed.air_threshold_quantile == 0.1
+
+
+def test_dict_roundtrip_classified() -> None:
+    seg = ThresholdMRI(classify_brain_tissues=True, skull_thickness_mm=5.0)
+    reconstructed = SegmentationMethod.from_dict(seg.to_dict())
+    assert reconstructed.classify_brain_tissues is True
+    assert "csf" in reconstructed.materials
+
+
+# --- Input validation ---
+
+def test_negative_skull_thickness_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        ThresholdMRI(skull_thickness_mm=-1.0)
+
+
+def test_invalid_air_quantile_raises() -> None:
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        ThresholdMRI(air_threshold_quantile=1.5)
+
+
+def test_negative_bias_sigma_raises() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        ThresholdMRI(bias_correction_sigma_mm=-5.0)
+
+
+def test_missing_material_key_raises() -> None:
+    with pytest.raises(ValueError, match="missing"):
+        ThresholdMRI(materials={"water": WATER, "tissue": TISSUE})
+
+
+def test_classify_with_tissue_ref_material_raises() -> None:
+    with pytest.raises(ValueError, match="removed during"):
+        ThresholdMRI(classify_brain_tissues=True, ref_material="tissue")
+
+
+def test_singleton_axis_raises() -> None:
+    coords = {"z": [0.0], "y": np.linspace(-10, 10, 21), "x": np.linspace(-10, 10, 21)}
+    volume = xa.DataArray(np.zeros((1, 21, 21)), dims=["z", "y", "x"], coords=coords)
+    with pytest.raises(ValueError, match="fewer than 2 coordinates"):
+        ThresholdMRI()._segment(volume)
+
+
+# --- Auto-swap behavior ---
+
+def test_materials_none_with_classification() -> None:
+    seg = ThresholdMRI(materials=None, classify_brain_tissues=True)
+    assert "csf" in seg.materials
+    assert "tissue" not in seg.materials
+
+
+def test_auto_swap_preserves_custom_materials() -> None:
+    custom_skull = Material(
+        name="skull", sound_speed=2800.0, density=1850.0,
+        attenuation=6.0, specific_heat=1100.0, thermal_conductivity=0.3,
+    )
+    custom = MATERIALS.copy()
+    custom["skull"] = custom_skull
+    seg = ThresholdMRI(classify_brain_tissues=True, materials=custom)
+    assert seg.materials["skull"].sound_speed == 2800.0
+    assert seg.materials["skull"].attenuation == 6.0
+
+
+def test_auto_swap_does_not_mutate_caller_dict() -> None:
+    original = MATERIALS.copy()
+    original_keys = set(original.keys())
+    ThresholdMRI(classify_brain_tissues=True, materials=original)
+    assert set(original.keys()) == original_keys
+
+
+# --- Core segmentation (4-label mode) ---
+
+def test_segment_synthetic_sphere(synthetic_sphere: xa.DataArray) -> None:
+    seg = ThresholdMRI(air_threshold_quantile=0.0)._segment(synthetic_sphere)
+    idx = ThresholdMRI(air_threshold_quantile=0.0)._material_indices()
+
+    assert seg.to_numpy()[0, 0, 0] == idx["water"]
+    assert np.any(seg.to_numpy() == idx["skull"])
+    center = tuple(s // 2 for s in seg.shape)
+    assert seg.to_numpy()[center] == idx["tissue"]
+    assert len(set(np.unique(seg.to_numpy()))) >= 3
+
+
+def test_segment_with_air_cavity() -> None:
+    volume = create_synthetic_head_volume()
+    # Explicitly set air_threshold_quantile to test the detection mechanism
+    # independent of the default value.
+    seg_method = ThresholdMRI(air_threshold_quantile=0.05)
+    center = 32
+    volume.to_numpy()[center - 3 : center + 3, center - 3 : center + 3, center - 3 : center + 3] = 0.1
+    seg = seg_method._segment(volume)
+    idx = seg_method._material_indices()
+    air_region = seg.to_numpy()[center - 3 : center + 3, center - 3 : center + 3, center - 3 : center + 3]
+    assert np.any(air_region == idx["air"])
+
+
+def test_different_thickness_changes_result(synthetic_sphere: xa.DataArray) -> None:
+    skull_idx = ThresholdMRI()._material_indices()["skull"]
+    thin = ThresholdMRI(skull_thickness_mm=3.0, air_threshold_quantile=0.0)._segment(synthetic_sphere)
+    thick = ThresholdMRI(skull_thickness_mm=12.0, air_threshold_quantile=0.0)._segment(synthetic_sphere)
+    assert int(np.sum(thick.to_numpy() == skull_idx)) > int(np.sum(thin.to_numpy() == skull_idx))
+
+
+# --- seg_params integration ---
+
+def test_seg_params_produces_heterogeneous_maps(synthetic_sphere: xa.DataArray) -> None:
+    params = ThresholdMRI(air_threshold_quantile=0.0).seg_params(synthetic_sphere)
+    expected_vars = {"sound_speed", "density", "attenuation", "specific_heat", "thermal_conductivity"}
+    assert set(params.data_vars) == expected_vars
+    for var_name in ("sound_speed", "density"):
+        arr = params[var_name].to_numpy()
+        assert not np.all(arr == arr.flat[0])
+
+
+def test_seg_params_correct_material_values(synthetic_sphere: xa.DataArray) -> None:
+    seg = ThresholdMRI(air_threshold_quantile=0.0)
+    ss = seg.seg_params(synthetic_sphere)["sound_speed"].to_numpy()
+    assert ss[0, 0, 0] == seg.materials["water"].sound_speed
+    center = tuple(s // 2 for s in ss.shape)
+    assert ss[center] == seg.materials["tissue"].sound_speed
+
+
+# --- Edge cases ---
+
+def test_empty_volume_returns_all_water() -> None:
+    volume = create_synthetic_head_volume(shape=(32, 32, 32), intensity=0.0)
+    volume.to_numpy()[:] = 0.0
+    seg = ThresholdMRI()._segment(volume)
+    assert np.all(seg.to_numpy() == ThresholdMRI()._material_indices()["water"])
+
+
+def test_nan_handling(synthetic_sphere: xa.DataArray, caplog: pytest.LogCaptureFixture) -> None:
+    volume = synthetic_sphere.copy(deep=True)
+    volume.to_numpy()[16, 16, 16] = np.nan
+    with caplog.at_level(logging.WARNING):
+        seg = ThresholdMRI()._segment(volume)
+    assert seg.shape == volume.shape
+    assert any("NaN" in r.message for r in caplog.records)
+
+
+def test_foreground_mask_failure_fallback() -> None:
+    volume = create_synthetic_head_volume(shape=(32, 32, 32))
+    water_idx = ThresholdMRI()._material_indices()["water"]
+    with patch(
+        "openlifu.seg.seg_methods.threshold_mri.compute_foreground_mask",
+        side_effect=ValueError("mocked"),
+    ):
+        seg = ThresholdMRI()._segment(volume)
+    assert np.all(seg.to_numpy() == water_idx)
+
+
+def test_skull_too_thick_warning(synthetic_sphere: xa.DataArray, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        ThresholdMRI(skull_thickness_mm=40.0)._segment(synthetic_sphere)
+    assert any("fewer than 10%" in r.message for r in caplog.records)
+
+
+# --- Spacing awareness ---
+
+def test_spacing_aware_skull_thickness() -> None:
+    seg = ThresholdMRI(skull_thickness_mm=7.0, air_threshold_quantile=0.0)
+    skull_idx = seg._material_indices()["skull"]
+
+    seg_1mm = seg._segment(create_synthetic_head_volume(shape=(64, 64, 64), spacing=1.0))
+    seg_2mm = seg._segment(create_synthetic_head_volume(shape=(32, 32, 32), spacing=2.0))
+
+    c1 = seg_1mm.shape[1] // 2
+    c2 = seg_2mm.shape[1] // 2
+    t1 = float(np.sum(seg_1mm.to_numpy()[:, c1, c1] == skull_idx)) * 1.0
+    t2 = float(np.sum(seg_2mm.to_numpy()[:, c2, c2] == skull_idx)) * 2.0
+
+    assert t2 < t1 * 1.5, f"2mm skull ({t2}mm) should not be 1.5x the 1mm ({t1}mm)"
+
+
+# --- Brain tissue classification (6-label mode) ---
+
+def test_classify_brain_three_tissues() -> None:
+    """Verify that the three-tissue sphere produces all expected labels:
+    center should be WM, and CSF, GM, WM, skull, and water should all be present.
+    Spatial smoothing is disabled so that the thin CSF shell (only 2-3 voxels
+    thick after skull erosion) is not absorbed by adjacent gray matter."""
+    volume = create_three_tissue_sphere()
+    seg = ThresholdMRI(classify_brain_tissues=True, air_threshold_quantile=0.0, spatial_sigma_mm=0.0, mrf_beta=0.0, skull_thickness_mm=7.0, brain_extraction_margin_mm=0.0)
+    result = seg._segment(volume)
+    idx = seg._material_indices()
+
+    center = tuple(s // 2 for s in result.shape)
+    assert result.to_numpy()[center] == idx["white_matter"]
+
+    unique = set(np.unique(result.to_numpy()))
+    for label in ("csf", "gray_matter", "white_matter", "skull", "water"):
+        assert idx[label] in unique, f"{label} should be present"
+
+
+def test_classify_brain_seg_params_attenuation_varies() -> None:
+    """Verify that attenuation values vary across voxels when brain tissues
+    are classified, confirming that distinct material properties are assigned."""
+    volume = create_three_tissue_sphere()
+    params = ThresholdMRI(classify_brain_tissues=True, air_threshold_quantile=0.0).seg_params(volume)
+    att = params["attenuation"].to_numpy()
+    assert not np.all(att == att.flat[0]), "Attenuation should vary with brain tissue classification"
+
+
+def test_classify_brain_gmm_failure_fallback() -> None:
+    """When the GMM fitting raises an exception, all parenchyma voxels should
+    fall back to the gray_matter label (the general exception handler)."""
+    volume = create_three_tissue_sphere()
+    seg = ThresholdMRI(classify_brain_tissues=True, air_threshold_quantile=0.0)
+    idx = seg._material_indices()
+    with patch.object(
+        ThresholdMRI,
+        "_classify_brain_gmm",
+        side_effect=RuntimeError("mocked GMM failure"),
+    ):
+        result = seg._segment(volume)
+    brain_labels = {idx["csf"], idx["gray_matter"], idx["white_matter"]}
+    brain_voxels = np.isin(result.to_numpy(), list(brain_labels))
+    if np.any(brain_voxels):
+        assert set(np.unique(result.to_numpy()[brain_voxels])) == {idx["gray_matter"]}
+
+
+def test_gmm_preserves_natural_class_proportions() -> None:
+    """EM-GMM should recover class proportions that reflect the actual geometry
+    of the concentric spheres, NOT force them to ~33% each (as histogram
+    equalization + multi-Otsu tends to do).
+
+    The three-tissue sphere has:
+      WM: r <= 0.5R   -> volume fraction = (0.5)^3 = 12.5%
+      GM: 0.5R < r <= 0.7R -> fraction = (0.7)^3 - (0.5)^3 = 21.8%
+      CSF: 0.7R < r <= R   -> fraction = 1 - (0.7)^3 = 65.7%
+
+    After skull erosion (7mm from 25mm radius), the outer CSF shell is clipped,
+    so the observed fractions differ from the raw geometry. We compute them
+    dynamically from the actual brain mask to set expectations.
+    """
+    shape = (64, 64, 64)
+    head_radius = 25.0
+    skull_thickness = 7.0
+
+    volume = create_three_tissue_sphere(shape=shape, head_radius=head_radius)
+    seg = ThresholdMRI(
+        classify_brain_tissues=True,
+        air_threshold_quantile=0.0,
+        bias_correction_sigma_mm=0.0,
+        spatial_sigma_mm=0.0,
+        mrf_beta=0.0,
+        skull_thickness_mm=skull_thickness,
+        brain_extraction_margin_mm=0.0,
+    )
+    result = seg._segment(volume)
+    idx = seg._material_indices()
+
+    # Compute expected proportions from the ground-truth geometry after
+    # accounting for skull erosion. The brain interior is voxels whose
+    # distance from the sphere boundary exceeds skull_thickness.
+    x = np.arange(64) * 1.0 - 31.5
+    zz, yy, xx = np.meshgrid(x, x, x, indexing="ij")
+    dist = np.sqrt(xx**2 + yy**2 + zz**2)
+
+    # The brain mask from the segmentation is: distance from background > skull_thickness.
+    # For a sphere, distance from background ~ head_radius - dist (approximately).
+    brain_mask = dist <= (head_radius - skull_thickness)
+    brain_total = int(np.sum(brain_mask))
+    assert brain_total > 0, "Brain mask should not be empty"
+
+    expected_wm_frac = float(np.sum(brain_mask & (dist <= head_radius * 0.5))) / brain_total
+    expected_gm_frac = float(np.sum(
+        brain_mask & (dist > head_radius * 0.5) & (dist <= head_radius * 0.7)
+    )) / brain_total
+    expected_csf_frac = float(np.sum(
+        brain_mask & (dist > head_radius * 0.7)
+    )) / brain_total
+
+    # Observed proportions from the segmentation
+    result_data = result.to_numpy()
+    brain_labels = {idx["csf"], idx["gray_matter"], idx["white_matter"]}
+    total_brain_voxels = sum(
+        int(np.sum(result_data == idx[k])) for k in ("csf", "gray_matter", "white_matter")
+    )
+    assert total_brain_voxels > 0, "Should have brain voxels"
+
+    obs_wm_frac = int(np.sum(result_data == idx["white_matter"])) / total_brain_voxels
+    obs_gm_frac = int(np.sum(result_data == idx["gray_matter"])) / total_brain_voxels
+    obs_csf_frac = int(np.sum(result_data == idx["csf"])) / total_brain_voxels
+
+    # The GMM should recover proportions within 15 percentage points of the
+    # geometric truth. The old equalize_hist approach would force all three
+    # classes to roughly 33%, which would fail this test for the CSF and WM
+    # fractions (expected CSF ~50%+, expected WM ~20%-).
+    tolerance = 0.15
+    assert abs(obs_wm_frac - expected_wm_frac) < tolerance, (
+        f"WM fraction {obs_wm_frac:.3f} should be within {tolerance} "
+        f"of expected {expected_wm_frac:.3f}"
+    )
+    assert abs(obs_gm_frac - expected_gm_frac) < tolerance, (
+        f"GM fraction {obs_gm_frac:.3f} should be within {tolerance} "
+        f"of expected {expected_gm_frac:.3f}"
+    )
+    assert abs(obs_csf_frac - expected_csf_frac) < tolerance, (
+        f"CSF fraction {obs_csf_frac:.3f} should be within {tolerance} "
+        f"of expected {expected_csf_frac:.3f}"
+    )
+
+    # Sanity check: the three fractions should NOT all be close to 0.33
+    # (which would indicate forced equal partitioning).
+    fracs = [obs_wm_frac, obs_gm_frac, obs_csf_frac]
+    assert not all(abs(f - 1.0 / 3.0) < 0.05 for f in fracs), (
+        f"All three fractions are near 33% ({fracs}), suggesting forced "
+        "equal partitioning rather than natural class proportions"
+    )
+
+
+def test_spatial_sigma_disables_smoothing_when_zero() -> None:
+    """With spatial_sigma_mm=0, no spatial regularization is applied. The
+    labels should be a direct per-voxel GMM classification without smoothing."""
+    shape = (64, 64, 64)
+    x = np.arange(64) * 1.0 - 31.5
+    zz, yy, xx = np.meshgrid(x, x, x, indexing="ij")
+    dist = np.sqrt(xx**2 + yy**2 + zz**2)
+
+    # Add noise to create noisy boundaries that smoothing would clean up
+    rng = np.random.default_rng(42)
+    noise = rng.normal(0, 8, shape)
+    data = np.zeros(shape)
+    head = dist <= 25.0
+    data[head] = 30.0 + noise[head]
+    data[dist <= 25.0 * 0.7] = 70.0 + noise[dist <= 25.0 * 0.7]
+    data[dist <= 25.0 * 0.5] = 100.0 + noise[dist <= 25.0 * 0.5]
+    data = np.clip(data, 0, None)
+
+    volume = xa.DataArray(data, dims=["z", "y", "x"], coords={"z": x, "y": x, "x": x})
+
+    seg_no_smooth = ThresholdMRI(
+        classify_brain_tissues=True,
+        air_threshold_quantile=0.0,
+        bias_correction_sigma_mm=0.0,
+        spatial_sigma_mm=0.0,
+        mrf_beta=0.0,
+        skull_thickness_mm=7.0,
+    )
+    result_no_smooth = seg_no_smooth._segment(volume)
+
+    seg_smooth = ThresholdMRI(
+        classify_brain_tissues=True,
+        air_threshold_quantile=0.0,
+        bias_correction_sigma_mm=0.0,
+        spatial_sigma_mm=1.0,
+        mrf_beta=0.0,
+        skull_thickness_mm=7.0,
+    )
+    result_smooth = seg_smooth._segment(volume)
+
+    idx = seg_no_smooth._material_indices()
+    brain_labels = [idx["csf"], idx["gray_matter"], idx["white_matter"]]
+
+    # Unsmoothed should produce all three brain labels
+    for label_name in ("csf", "gray_matter", "white_matter"):
+        assert np.any(result_no_smooth.to_numpy() == idx[label_name]), (
+            f"{label_name} missing from unsmoothed result"
+        )
+
+    # Smoothed should produce at least two brain labels (thin CSF shell may
+    # be absorbed by adjacent GM with stronger smoothing on small phantoms)
+    smoothed_brain_count = sum(
+        1 for lbl in brain_labels if np.any(result_smooth.to_numpy() == lbl)
+    )
+    assert smoothed_brain_count >= 2, (
+        "Smoothed result should contain at least 2 distinct brain tissue labels"
+    )
+
+    # Measure label-boundary roughness: count voxels where the label differs
+    # from at least one of its 6-connected neighbors (within brain voxels only).
+    def count_boundary_voxels(seg_arr: np.ndarray) -> int:
+        brain_mask = np.isin(seg_arr, brain_labels)
+        boundary = np.zeros_like(brain_mask)
+        for axis in range(3):
+            shifted_fwd = np.roll(seg_arr, 1, axis=axis)
+            shifted_bwd = np.roll(seg_arr, -1, axis=axis)
+            boundary |= (seg_arr != shifted_fwd) & brain_mask
+            boundary |= (seg_arr != shifted_bwd) & brain_mask
+        return int(np.sum(boundary))
+
+    boundaries_no_smooth = count_boundary_voxels(result_no_smooth.to_numpy())
+    boundaries_smooth = count_boundary_voxels(result_smooth.to_numpy())
+
+    # Spatial smoothing should reduce boundary voxels (smoother label maps).
+    assert boundaries_smooth < boundaries_no_smooth, (
+        f"Smoothed result ({boundaries_smooth} boundary voxels) should have "
+        f"fewer boundary voxels than unsmoothed ({boundaries_no_smooth})"
+    )
+
+
+def test_spatial_sigma_positive_produces_smoother_labels() -> None:
+    """Increasing spatial_sigma_mm should monotonically reduce label noise.
+    Compare sigma=1 vs sigma=5 on a noisy phantom."""
+    shape = (64, 64, 64)
+    x = np.arange(64) * 1.0 - 31.5
+    zz, yy, xx = np.meshgrid(x, x, x, indexing="ij")
+    dist = np.sqrt(xx**2 + yy**2 + zz**2)
+
+    rng = np.random.default_rng(99)
+    noise = rng.normal(0, 10, shape)
+    data = np.zeros(shape)
+    head = dist <= 25.0
+    data[head] = 30.0 + noise[head]
+    data[dist <= 25.0 * 0.7] = 70.0 + noise[dist <= 25.0 * 0.7]
+    data[dist <= 25.0 * 0.5] = 100.0 + noise[dist <= 25.0 * 0.5]
+    data = np.clip(data, 0, None)
+
+    volume = xa.DataArray(data, dims=["z", "y", "x"], coords={"z": x, "y": x, "x": x})
+
+    def count_label_transitions(seg_arr: np.ndarray, brain_label_set: list[int]) -> int:
+        brain_mask = np.isin(seg_arr, brain_label_set)
+        transitions = 0
+        for axis in range(3):
+            shifted = np.roll(seg_arr, 1, axis=axis)
+            transitions += int(np.sum((seg_arr != shifted) & brain_mask))
+        return transitions
+
+    seg_small = ThresholdMRI(
+        classify_brain_tissues=True,
+        air_threshold_quantile=0.0,
+        bias_correction_sigma_mm=0.0,
+        spatial_sigma_mm=1.0,
+        mrf_beta=0.0,
+        skull_thickness_mm=7.0,
+    )
+    seg_large = ThresholdMRI(
+        classify_brain_tissues=True,
+        air_threshold_quantile=0.0,
+        bias_correction_sigma_mm=0.0,
+        spatial_sigma_mm=5.0,
+        mrf_beta=0.0,
+        skull_thickness_mm=7.0,
+    )
+
+    result_small = seg_small._segment(volume)
+    result_large = seg_large._segment(volume)
+
+    idx = seg_small._material_indices()
+    brain_labels = [idx["csf"], idx["gray_matter"], idx["white_matter"]]
+
+    trans_small = count_label_transitions(result_small.to_numpy(), brain_labels)
+    trans_large = count_label_transitions(result_large.to_numpy(), brain_labels)
+
+    assert trans_large < trans_small, (
+        f"Larger sigma ({trans_large} transitions) should produce fewer "
+        f"label transitions than smaller sigma ({trans_small})"
+    )

--- a/tests/test_threshold_mri.py
+++ b/tests/test_threshold_mri.py
@@ -247,10 +247,10 @@ def test_spacing_aware_skull_thickness() -> None:
 def test_classify_brain_three_tissues() -> None:
     """Verify that the three-tissue sphere produces all expected labels:
     center should be WM, and CSF, GM, WM, skull, and water should all be present.
-    Spatial smoothing is disabled so that the thin CSF shell (only 2-3 voxels
-    thick after skull erosion) is not absorbed by adjacent gray matter."""
+    The thin CSF shell (only 2-3 voxels thick after skull erosion) must be
+    preserved and not absorbed by adjacent gray matter."""
     volume = create_three_tissue_sphere()
-    seg = ThresholdMRI(classify_brain_tissues=True, air_threshold_quantile=0.0, spatial_sigma_mm=0.0, mrf_beta=0.0, skull_thickness_mm=7.0, brain_extraction_margin_mm=0.0)
+    seg = ThresholdMRI(classify_brain_tissues=True, air_threshold_quantile=0.0, skull_thickness_mm=7.0, brain_extraction_margin_mm=0.0)
     result = seg._segment(volume)
     idx = seg._material_indices()
 
@@ -337,8 +337,6 @@ def test_gmm_preserves_natural_class_proportions() -> None:
         classify_brain_tissues=True,
         air_threshold_quantile=0.0,
         bias_correction_sigma_mm=0.0,
-        spatial_sigma_mm=0.0,
-        mrf_beta=0.0,
         skull_thickness_mm=skull_thickness,
         brain_extraction_margin_mm=0.0,
     )
@@ -402,143 +400,4 @@ def test_gmm_preserves_natural_class_proportions() -> None:
     assert not all(abs(f - 1.0 / 3.0) < 0.05 for f in fracs), (
         f"All three fractions are near 33% ({fracs}), suggesting forced "
         "equal partitioning rather than natural class proportions"
-    )
-
-
-def test_spatial_sigma_disables_smoothing_when_zero() -> None:
-    """With spatial_sigma_mm=0, no spatial regularization is applied. The
-    labels should be a direct per-voxel GMM classification without smoothing."""
-    shape = (64, 64, 64)
-    x = np.arange(64) * 1.0 - 31.5
-    zz, yy, xx = np.meshgrid(x, x, x, indexing="ij")
-    dist = np.sqrt(xx**2 + yy**2 + zz**2)
-
-    # Add noise to create noisy boundaries that smoothing would clean up
-    rng = np.random.default_rng(42)
-    noise = rng.normal(0, 8, shape)
-    data = np.zeros(shape)
-    head = dist <= 25.0
-    data[head] = 30.0 + noise[head]
-    data[dist <= 25.0 * 0.7] = 70.0 + noise[dist <= 25.0 * 0.7]
-    data[dist <= 25.0 * 0.5] = 100.0 + noise[dist <= 25.0 * 0.5]
-    data = np.clip(data, 0, None)
-
-    volume = xa.DataArray(data, dims=["z", "y", "x"], coords={"z": x, "y": x, "x": x})
-
-    seg_no_smooth = ThresholdMRI(
-        classify_brain_tissues=True,
-        air_threshold_quantile=0.0,
-        bias_correction_sigma_mm=0.0,
-        spatial_sigma_mm=0.0,
-        mrf_beta=0.0,
-        skull_thickness_mm=7.0,
-    )
-    result_no_smooth = seg_no_smooth._segment(volume)
-
-    seg_smooth = ThresholdMRI(
-        classify_brain_tissues=True,
-        air_threshold_quantile=0.0,
-        bias_correction_sigma_mm=0.0,
-        spatial_sigma_mm=1.0,
-        mrf_beta=0.0,
-        skull_thickness_mm=7.0,
-    )
-    result_smooth = seg_smooth._segment(volume)
-
-    idx = seg_no_smooth._material_indices()
-    brain_labels = [idx["csf"], idx["gray_matter"], idx["white_matter"]]
-
-    # Unsmoothed should produce all three brain labels
-    for label_name in ("csf", "gray_matter", "white_matter"):
-        assert np.any(result_no_smooth.to_numpy() == idx[label_name]), (
-            f"{label_name} missing from unsmoothed result"
-        )
-
-    # Smoothed should produce at least two brain labels (thin CSF shell may
-    # be absorbed by adjacent GM with stronger smoothing on small phantoms)
-    smoothed_brain_count = sum(
-        1 for lbl in brain_labels if np.any(result_smooth.to_numpy() == lbl)
-    )
-    assert smoothed_brain_count >= 2, (
-        "Smoothed result should contain at least 2 distinct brain tissue labels"
-    )
-
-    # Measure label-boundary roughness: count voxels where the label differs
-    # from at least one of its 6-connected neighbors (within brain voxels only).
-    def count_boundary_voxels(seg_arr: np.ndarray) -> int:
-        brain_mask = np.isin(seg_arr, brain_labels)
-        boundary = np.zeros_like(brain_mask)
-        for axis in range(3):
-            shifted_fwd = np.roll(seg_arr, 1, axis=axis)
-            shifted_bwd = np.roll(seg_arr, -1, axis=axis)
-            boundary |= (seg_arr != shifted_fwd) & brain_mask
-            boundary |= (seg_arr != shifted_bwd) & brain_mask
-        return int(np.sum(boundary))
-
-    boundaries_no_smooth = count_boundary_voxels(result_no_smooth.to_numpy())
-    boundaries_smooth = count_boundary_voxels(result_smooth.to_numpy())
-
-    # Spatial smoothing should reduce boundary voxels (smoother label maps).
-    assert boundaries_smooth < boundaries_no_smooth, (
-        f"Smoothed result ({boundaries_smooth} boundary voxels) should have "
-        f"fewer boundary voxels than unsmoothed ({boundaries_no_smooth})"
-    )
-
-
-def test_spatial_sigma_positive_produces_smoother_labels() -> None:
-    """Increasing spatial_sigma_mm should monotonically reduce label noise.
-    Compare sigma=1 vs sigma=5 on a noisy phantom."""
-    shape = (64, 64, 64)
-    x = np.arange(64) * 1.0 - 31.5
-    zz, yy, xx = np.meshgrid(x, x, x, indexing="ij")
-    dist = np.sqrt(xx**2 + yy**2 + zz**2)
-
-    rng = np.random.default_rng(99)
-    noise = rng.normal(0, 10, shape)
-    data = np.zeros(shape)
-    head = dist <= 25.0
-    data[head] = 30.0 + noise[head]
-    data[dist <= 25.0 * 0.7] = 70.0 + noise[dist <= 25.0 * 0.7]
-    data[dist <= 25.0 * 0.5] = 100.0 + noise[dist <= 25.0 * 0.5]
-    data = np.clip(data, 0, None)
-
-    volume = xa.DataArray(data, dims=["z", "y", "x"], coords={"z": x, "y": x, "x": x})
-
-    def count_label_transitions(seg_arr: np.ndarray, brain_label_set: list[int]) -> int:
-        brain_mask = np.isin(seg_arr, brain_label_set)
-        transitions = 0
-        for axis in range(3):
-            shifted = np.roll(seg_arr, 1, axis=axis)
-            transitions += int(np.sum((seg_arr != shifted) & brain_mask))
-        return transitions
-
-    seg_small = ThresholdMRI(
-        classify_brain_tissues=True,
-        air_threshold_quantile=0.0,
-        bias_correction_sigma_mm=0.0,
-        spatial_sigma_mm=1.0,
-        mrf_beta=0.0,
-        skull_thickness_mm=7.0,
-    )
-    seg_large = ThresholdMRI(
-        classify_brain_tissues=True,
-        air_threshold_quantile=0.0,
-        bias_correction_sigma_mm=0.0,
-        spatial_sigma_mm=5.0,
-        mrf_beta=0.0,
-        skull_thickness_mm=7.0,
-    )
-
-    result_small = seg_small._segment(volume)
-    result_large = seg_large._segment(volume)
-
-    idx = seg_small._material_indices()
-    brain_labels = [idx["csf"], idx["gray_matter"], idx["white_matter"]]
-
-    trans_small = count_label_transitions(result_small.to_numpy(), brain_labels)
-    trans_large = count_label_transitions(result_large.to_numpy(), brain_labels)
-
-    assert trans_large < trans_small, (
-        f"Larger sigma ({trans_large} transitions) should produce fewer "
-        f"label transitions than smaller sigma ({trans_small})"
     )


### PR DESCRIPTION
## Summary

Adds `ThresholdMRI`, a new `SegmentationMethod` for transcranial focused ultrasound planning that segments T1-weighted MRI into skull, brain tissue, air, and water regions. Also adds `SimulationCorrected`, a new `DelayMethod` that uses k-wave simulation with acoustic reciprocity to compute phase-corrected transducer delays through the segmented skull model.

Fixes material attenuation values in `material.py` (previously all 0.0, which meant attenuation had no effect in simulations). Enables N4 bias correction by default with a 12x speedup via shrink-factor fitting. Cleans up temporary H5 files left by k-wave simulations (#435).

Closes #150
Fixes #435

## What this PR delivers

**Segmentation (ThresholdMRI):**
- 4-label default mode: water, skull, tissue, air (via EDT erosion + Otsu intensity refinement)
- 6-label opt-in mode: further classifies brain tissue into CSF, gray matter, white matter (via EM-GMM)
- Auto-detection of skull-stripped input
- N4 bias correction enabled by default (0.36s with shrink=4, falls back to homomorphic if SimpleITK unavailable)
- No new required dependencies

**Phase correction (SimulationCorrected):**
- Reciprocity-based: one k-wave simulation per target (not per element)
- Places virtual point source at target, records at all element positions
- Extracts arrival times via Hilbert envelope, computes corrective delays
- Expected: focal pressure recovery from 20-40% to 50-70%, focal shift from 1-5mm to ~1mm
- Falls back to Direct (geometric) delays if k-wave unavailable

**Material fix:**
- water: 0.0 -> 0.002 dB/cm/MHz
- tissue: 0.0 -> 0.6 dB/cm/MHz
- skull: 0.0 -> 8.0 dB/cm/MHz
- air: 0.0 -> 1.64 dB/cm/MHz

**k-wave temp file cleanup (#435):**
- Both \`run_simulation\` and \`run_point_source_simulation\` now delete their H5 input/output files after completing, preventing accumulation in the temp directory.

## Validation

**Skull segmentation (4-label mode):**

| Dataset | Scans | Skull Dice | Brain Dice |
|---------|-------|-----------|------------|
| Birnbaum (68 stroke patients, 3 sites) | 68 | 0.315 | 0.713 |
| Ernie (SimNIBS CHARM labels) | 1 | 0.578 | 0.667 |

**Brain mask agreement (4-label mode):**

| Dataset | Scans | Brain Dice |
|---------|-------|------------|
| Neurite-OASIS (FreeSurfer labels) | 404 | 0.654 |
| SynthStrip (15 modalities) | 582 | 0.728 |

**Brain tissue classification (6-label mode, skull-stripped input, Neurite 10 subjects):**

| Tissue | ThresholdMRI | ANTs Atropos |
|--------|-------------|-------------|
| GM | 0.822 | 0.79 |
| WM | 0.853 | 0.84 |
| CSF | 0.169 | 0.64 |

**Acoustic property validation (per Ebrahim's request):**

| Metric | Ernie | Birnbaum (5 mean) |
|--------|-------|-------------------|
| Sound speed accuracy | 85.2% | 91.6% |
| Bone sensitivity | 34.2% | 58.9% |

## Known limitations

- Skull Dice (0.315 on Birnbaum) is below conventional T1 methods (0.73-0.80). This is inherent to threshold-based T1-only segmentation; bone is a signal void on T1.
- CSF Dice (0.169) is below ANTs (0.64). The EM-GMM lacks spatial priors.
- 6-label mode does not work well on whole-head (non-skull-stripped) data. The GMM is contaminated by scalp/muscle tissue. Works well on skull-stripped input.
- Phase correction has not been validated end-to-end with hydrophone measurements.

## Future work (separate PRs)

- **Pseudo-CT from T1 MRI:** Integration with [mr-to-pct](https://github.com/sitiny/mr-to-pct) (Apache 2.0) for continuous Hounsfield Unit skull maps instead of binary segmentation. Prototype shows 3.28x bone Dice improvement on Ernie (0.169 to 0.554). Would add MONAI + PyTorch as optional dependencies.
- **Atlas-based tissue priors:** ICBM152 tissue probability maps via nilearn for better GM/WM/CSF classification.
- **End-to-end phase correction validation:** Run SimulationCorrected through the full FUS planning pipeline and compare focal pressure/position against ground truth.

## Test plan

- [x] 28 ThresholdMRI tests (serialization, validation, segmentation, edge cases, brain tissue classification)
- [x] 16 SimulationCorrected tests (construction, validation, serialization, round-trip dispatch)
- [x] Existing test suites unaffected (222 passed, 2 skipped)
- [x] CI passes on all platforms (Python 3.10/3.12, ubuntu/windows/macos)