### PR TITLE
Update photoscan reconstruction to use Meshroom 2025

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,12 +65,12 @@ Ubuntu
 
 Download and Extract
 ^^^^^^^^^^^^^^^^^^^^
-1. Download Meshroom 2023.3.0 for Linux from `<https://github.com/alicevision/Meshroom/releases/tag/v2023.3.0>`_.
+1. Download Meshroom 2025.1.0 for Linux from `<https://github.com/alicevision/Meshroom/releases/tag/v2025.1.0>`_.
 2. Extract the downloaded archive:
 
    .. code:: bash
 
-      tar -xvf Meshroom-2023.3.0.tar.gz
+      tar -xvf Meshroom-2025.1.0-Linux.tar.gz
 
 Add Meshroom to PATH
 ^^^^^^^^^^^^^^^^^^^^
@@ -98,7 +98,7 @@ Windows
 Download and Extract
 ^^^^^^^^^^^^^^^^^^^^
 
-1. Download Meshroom 2023.3.0 for Windows from `<https://github.com/alicevision/Meshroom/releases/tag/v2023.3.0>`_.
+1. Download Meshroom 2025.1.0 for Windows from `<https://github.com/alicevision/Meshroom/releases/tag/v2025.1.0>`_.
 2. Extract the downloaded archive to a directory of your choice.
 
 Add Meshroom to PATH

--- a/src/openlifu/nav/meshroom_pipelines/default_pipeline.mg
+++ b/src/openlifu/nav/meshroom_pipelines/default_pipeline.mg
@@ -1,133 +1,98 @@
 {
     "header": {
-        "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
-        "fileVersion": "1.1",
-        "template": true,
+        "releaseVersion": "2025.1.0",
+        "fileVersion": "2.0",
         "nodesVersions": {
-            "MeshFiltering": "3.0",
-            "DepthMapFilter": "4.0",
-            "MeshDecimate": "1.0",
-            "Meshing": "7.0",
-            "FeatureExtraction": "1.3",
-            "CameraInit": "9.0",
-            "Texturing": "6.0",
-            "ImageMatching": "2.0",
-            "Publish": "1.3",
+            "CameraInit": "12.0",
             "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "StructureFromMotion": "3.3"
+            "Publish": "1.3",
+            "StructureFromMotion": "3.3",
+            "Texturing": "6.0"
         }
     },
     "graph": {
-        "Meshing_1": {
-            "nodeType": "Meshing",
-            "position": [
-                1600,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMapFilter_1.input}",
-                "depthMapsFolder": "{DepthMapFilter_1.output}"
-            }
-        },
-        "DepthMapFilter_1": {
-            "nodeType": "DepthMapFilter",
-            "position": [
-                1400,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMap_1.input}",
-                "depthMapsFolder": "{DepthMap_1.output}"
-            }
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [0, 0],
+            "inputs": {}
         },
         "FeatureExtraction_1": {
             "nodeType": "FeatureExtraction",
-            "position": [
-                200,
-                0
-            ],
+            "position": [200, 0],
             "inputs": {
                 "input": "{CameraInit_1.output}",
+                "describerTypes": ["dspsift"],
                 "forceCpuExtraction": false
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [400, 0],
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": ["{FeatureExtraction_1.output}"],
+                "imagePairsList": "",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
             }
         },
         "StructureFromMotion_1": {
             "nodeType": "StructureFromMotion",
-            "position": [
-                800,
-                0
-            ],
+            "position": [600, 0],
             "inputs": {
                 "input": "{FeatureMatching_1.input}",
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}",
-                "matchesFolders": [
-                    "{FeatureMatching_1.output}"
-                ],
+                "matchesFolders": ["{FeatureMatching_1.output}"],
                 "describerTypes": "{FeatureMatching_1.describerTypes}"
             }
         },
         "PrepareDenseScene_1": {
             "nodeType": "PrepareDenseScene",
-            "position": [
-                1000,
-                0
-            ],
+            "position": [800, 0],
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
             }
         },
-        "CameraInit_1": {
-            "nodeType": "CameraInit",
-            "position": [
-                0,
-                0
-            ],
-            "inputs": {}
-        },
         "DepthMap_1": {
             "nodeType": "DepthMap",
-            "position": [
-                1200,
-                0
-            ],
+            "position": [1000, 0],
             "inputs": {
                 "input": "{PrepareDenseScene_1.input}",
                 "imagesFolder": "{PrepareDenseScene_1.output}",
                 "downscale": 2
             }
         },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [1200, 0],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [1400, 0],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}"
+            }
+        },
         "MeshFiltering_1": {
             "nodeType": "MeshFiltering",
-            "position": [
-                1800,
-                0
-            ],
+            "position": [1600, 0],
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}"
             }
         },
-        "FeatureMatching_1": {
-            "nodeType": "FeatureMatching",
-            "position": [
-                600,
-                0
-            ],
-            "inputs": {
-                "input": "{FeatureExtraction_1.input}",
-                "featuresFolders": "{FeatureExtraction_1.output}",
-                "imagePairsList": "{}",
-                "describerTypes": "{FeatureExtraction_1.describerTypes}"
-            }
-        },
         "Texturing_1": {
             "nodeType": "Texturing",
-            "position": [
-                2178,
-                24
-            ],
+            "position": [1800, 0],
             "inputs": {
                 "input": "{Meshing_1.output}",
                 "imagesFolder": "{DepthMap_1.imagesFolder}",
@@ -140,10 +105,7 @@
         },
         "Publish_1": {
             "nodeType": "Publish",
-            "position": [
-                2272,
-                290
-            ],
+            "position": [2000, 0],
             "inputs": {
                 "inputFiles": [
                     "{Texturing_1.output}",

--- a/src/openlifu/nav/meshroom_pipelines/downsample_1x_pipeline.mg
+++ b/src/openlifu/nav/meshroom_pipelines/downsample_1x_pipeline.mg
@@ -1,133 +1,98 @@
 {
     "header": {
-        "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
-        "fileVersion": "1.1",
-        "template": true,
+        "releaseVersion": "2025.1.0",
+        "fileVersion": "2.0",
         "nodesVersions": {
-            "MeshFiltering": "3.0",
-            "DepthMapFilter": "4.0",
-            "MeshDecimate": "1.0",
-            "Meshing": "7.0",
-            "FeatureExtraction": "1.3",
-            "CameraInit": "9.0",
-            "Texturing": "6.0",
-            "ImageMatching": "2.0",
-            "Publish": "1.3",
+            "CameraInit": "12.0",
             "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "StructureFromMotion": "3.3"
+            "Publish": "1.3",
+            "StructureFromMotion": "3.3",
+            "Texturing": "6.0"
         }
     },
     "graph": {
-        "Meshing_1": {
-            "nodeType": "Meshing",
-            "position": [
-                1600,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMapFilter_1.input}",
-                "depthMapsFolder": "{DepthMapFilter_1.output}"
-            }
-        },
-        "DepthMapFilter_1": {
-            "nodeType": "DepthMapFilter",
-            "position": [
-                1400,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMap_1.input}",
-                "depthMapsFolder": "{DepthMap_1.output}"
-            }
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [0, 0],
+            "inputs": {}
         },
         "FeatureExtraction_1": {
             "nodeType": "FeatureExtraction",
-            "position": [
-                200,
-                0
-            ],
+            "position": [200, 0],
             "inputs": {
                 "input": "{CameraInit_1.output}",
+                "describerTypes": ["dspsift"],
                 "forceCpuExtraction": false
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [400, 0],
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": ["{FeatureExtraction_1.output}"],
+                "imagePairsList": "",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
             }
         },
         "StructureFromMotion_1": {
             "nodeType": "StructureFromMotion",
-            "position": [
-                800,
-                0
-            ],
+            "position": [600, 0],
             "inputs": {
                 "input": "{FeatureMatching_1.input}",
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}",
-                "matchesFolders": [
-                    "{FeatureMatching_1.output}"
-                ],
+                "matchesFolders": ["{FeatureMatching_1.output}"],
                 "describerTypes": "{FeatureMatching_1.describerTypes}"
             }
         },
         "PrepareDenseScene_1": {
             "nodeType": "PrepareDenseScene",
-            "position": [
-                1000,
-                0
-            ],
+            "position": [800, 0],
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
             }
         },
-        "CameraInit_1": {
-            "nodeType": "CameraInit",
-            "position": [
-                0,
-                0
-            ],
-            "inputs": {}
-        },
         "DepthMap_1": {
             "nodeType": "DepthMap",
-            "position": [
-                1200,
-                0
-            ],
+            "position": [1000, 0],
             "inputs": {
                 "input": "{PrepareDenseScene_1.input}",
                 "imagesFolder": "{PrepareDenseScene_1.output}",
                 "downscale": 1
             }
         },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [1200, 0],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [1400, 0],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}"
+            }
+        },
         "MeshFiltering_1": {
             "nodeType": "MeshFiltering",
-            "position": [
-                1800,
-                0
-            ],
+            "position": [1600, 0],
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}"
             }
         },
-        "FeatureMatching_1": {
-            "nodeType": "FeatureMatching",
-            "position": [
-                600,
-                0
-            ],
-            "inputs": {
-                "input": "{FeatureExtraction_1.input}",
-                "featuresFolders": "{FeatureExtraction_1.output}",
-                "imagePairsList": "{}",
-                "describerTypes": "{FeatureExtraction_1.describerTypes}"
-            }
-        },
         "Texturing_1": {
             "nodeType": "Texturing",
-            "position": [
-                2178,
-                24
-            ],
+            "position": [1800, 0],
             "inputs": {
                 "input": "{Meshing_1.output}",
                 "imagesFolder": "{DepthMap_1.imagesFolder}",
@@ -140,10 +105,7 @@
         },
         "Publish_1": {
             "nodeType": "Publish",
-            "position": [
-                2272,
-                290
-            ],
+            "position": [2000, 0],
             "inputs": {
                 "inputFiles": [
                     "{Texturing_1.output}",

--- a/src/openlifu/nav/meshroom_pipelines/downsample_4x_pipeline.mg
+++ b/src/openlifu/nav/meshroom_pipelines/downsample_4x_pipeline.mg
@@ -1,133 +1,98 @@
 {
     "header": {
-        "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
-        "fileVersion": "1.1",
-        "template": true,
+        "releaseVersion": "2025.1.0",
+        "fileVersion": "2.0",
         "nodesVersions": {
-            "MeshFiltering": "3.0",
-            "DepthMapFilter": "4.0",
-            "MeshDecimate": "1.0",
-            "Meshing": "7.0",
-            "FeatureExtraction": "1.3",
-            "CameraInit": "9.0",
-            "Texturing": "6.0",
-            "ImageMatching": "2.0",
-            "Publish": "1.3",
+            "CameraInit": "12.0",
             "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "StructureFromMotion": "3.3"
+            "Publish": "1.3",
+            "StructureFromMotion": "3.3",
+            "Texturing": "6.0"
         }
     },
     "graph": {
-        "Meshing_1": {
-            "nodeType": "Meshing",
-            "position": [
-                1600,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMapFilter_1.input}",
-                "depthMapsFolder": "{DepthMapFilter_1.output}"
-            }
-        },
-        "DepthMapFilter_1": {
-            "nodeType": "DepthMapFilter",
-            "position": [
-                1400,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMap_1.input}",
-                "depthMapsFolder": "{DepthMap_1.output}"
-            }
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [0, 0],
+            "inputs": {}
         },
         "FeatureExtraction_1": {
             "nodeType": "FeatureExtraction",
-            "position": [
-                200,
-                0
-            ],
+            "position": [200, 0],
             "inputs": {
                 "input": "{CameraInit_1.output}",
+                "describerTypes": ["dspsift"],
                 "forceCpuExtraction": false
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [400, 0],
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": ["{FeatureExtraction_1.output}"],
+                "imagePairsList": "",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
             }
         },
         "StructureFromMotion_1": {
             "nodeType": "StructureFromMotion",
-            "position": [
-                800,
-                0
-            ],
+            "position": [600, 0],
             "inputs": {
                 "input": "{FeatureMatching_1.input}",
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}",
-                "matchesFolders": [
-                    "{FeatureMatching_1.output}"
-                ],
+                "matchesFolders": ["{FeatureMatching_1.output}"],
                 "describerTypes": "{FeatureMatching_1.describerTypes}"
             }
         },
         "PrepareDenseScene_1": {
             "nodeType": "PrepareDenseScene",
-            "position": [
-                1000,
-                0
-            ],
+            "position": [800, 0],
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
             }
         },
-        "CameraInit_1": {
-            "nodeType": "CameraInit",
-            "position": [
-                0,
-                0
-            ],
-            "inputs": {}
-        },
         "DepthMap_1": {
             "nodeType": "DepthMap",
-            "position": [
-                1200,
-                0
-            ],
+            "position": [1000, 0],
             "inputs": {
                 "input": "{PrepareDenseScene_1.input}",
                 "imagesFolder": "{PrepareDenseScene_1.output}",
                 "downscale": 4
             }
         },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [1200, 0],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [1400, 0],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}"
+            }
+        },
         "MeshFiltering_1": {
             "nodeType": "MeshFiltering",
-            "position": [
-                1800,
-                0
-            ],
+            "position": [1600, 0],
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}"
             }
         },
-        "FeatureMatching_1": {
-            "nodeType": "FeatureMatching",
-            "position": [
-                600,
-                0
-            ],
-            "inputs": {
-                "input": "{FeatureExtraction_1.input}",
-                "featuresFolders": "{FeatureExtraction_1.output}",
-                "imagePairsList": "{}",
-                "describerTypes": "{FeatureExtraction_1.describerTypes}"
-            }
-        },
         "Texturing_1": {
             "nodeType": "Texturing",
-            "position": [
-                2178,
-                24
-            ],
+            "position": [1800, 0],
             "inputs": {
                 "input": "{Meshing_1.output}",
                 "imagesFolder": "{DepthMap_1.imagesFolder}",
@@ -140,10 +105,7 @@
         },
         "Publish_1": {
             "nodeType": "Publish",
-            "position": [
-                2272,
-                290
-            ],
+            "position": [2000, 0],
             "inputs": {
                 "inputFiles": [
                     "{Texturing_1.output}",

--- a/src/openlifu/nav/meshroom_pipelines/downsample_8x_pipeline.mg
+++ b/src/openlifu/nav/meshroom_pipelines/downsample_8x_pipeline.mg
@@ -1,133 +1,98 @@
 {
     "header": {
-        "pipelineVersion": "2.2",
-        "releaseVersion": "2023.3.0",
-        "fileVersion": "1.1",
-        "template": true,
+        "releaseVersion": "2025.1.0",
+        "fileVersion": "2.0",
         "nodesVersions": {
-            "MeshFiltering": "3.0",
-            "DepthMapFilter": "4.0",
-            "MeshDecimate": "1.0",
-            "Meshing": "7.0",
-            "FeatureExtraction": "1.3",
-            "CameraInit": "9.0",
-            "Texturing": "6.0",
-            "ImageMatching": "2.0",
-            "Publish": "1.3",
+            "CameraInit": "12.0",
             "DepthMap": "5.0",
+            "DepthMapFilter": "4.0",
+            "FeatureExtraction": "1.3",
             "FeatureMatching": "2.0",
+            "MeshFiltering": "3.0",
+            "Meshing": "7.0",
             "PrepareDenseScene": "3.1",
-            "StructureFromMotion": "3.3"
+            "Publish": "1.3",
+            "StructureFromMotion": "3.3",
+            "Texturing": "6.0"
         }
     },
     "graph": {
-        "Meshing_1": {
-            "nodeType": "Meshing",
-            "position": [
-                1600,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMapFilter_1.input}",
-                "depthMapsFolder": "{DepthMapFilter_1.output}"
-            }
-        },
-        "DepthMapFilter_1": {
-            "nodeType": "DepthMapFilter",
-            "position": [
-                1400,
-                0
-            ],
-            "inputs": {
-                "input": "{DepthMap_1.input}",
-                "depthMapsFolder": "{DepthMap_1.output}"
-            }
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [0, 0],
+            "inputs": {}
         },
         "FeatureExtraction_1": {
             "nodeType": "FeatureExtraction",
-            "position": [
-                200,
-                0
-            ],
+            "position": [200, 0],
             "inputs": {
                 "input": "{CameraInit_1.output}",
+                "describerTypes": ["dspsift"],
                 "forceCpuExtraction": false
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [400, 0],
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": ["{FeatureExtraction_1.output}"],
+                "imagePairsList": "",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
             }
         },
         "StructureFromMotion_1": {
             "nodeType": "StructureFromMotion",
-            "position": [
-                800,
-                0
-            ],
+            "position": [600, 0],
             "inputs": {
                 "input": "{FeatureMatching_1.input}",
                 "featuresFolders": "{FeatureMatching_1.featuresFolders}",
-                "matchesFolders": [
-                    "{FeatureMatching_1.output}"
-                ],
+                "matchesFolders": ["{FeatureMatching_1.output}"],
                 "describerTypes": "{FeatureMatching_1.describerTypes}"
             }
         },
         "PrepareDenseScene_1": {
             "nodeType": "PrepareDenseScene",
-            "position": [
-                1000,
-                0
-            ],
+            "position": [800, 0],
             "inputs": {
                 "input": "{StructureFromMotion_1.output}"
             }
         },
-        "CameraInit_1": {
-            "nodeType": "CameraInit",
-            "position": [
-                0,
-                0
-            ],
-            "inputs": {}
-        },
         "DepthMap_1": {
             "nodeType": "DepthMap",
-            "position": [
-                1200,
-                0
-            ],
+            "position": [1000, 0],
             "inputs": {
                 "input": "{PrepareDenseScene_1.input}",
                 "imagesFolder": "{PrepareDenseScene_1.output}",
                 "downscale": 8
             }
         },
+        "DepthMapFilter_1": {
+            "nodeType": "DepthMapFilter",
+            "position": [1200, 0],
+            "inputs": {
+                "input": "{DepthMap_1.input}",
+                "depthMapsFolder": "{DepthMap_1.output}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [1400, 0],
+            "inputs": {
+                "input": "{DepthMapFilter_1.input}",
+                "depthMapsFolder": "{DepthMapFilter_1.output}"
+            }
+        },
         "MeshFiltering_1": {
             "nodeType": "MeshFiltering",
-            "position": [
-                1800,
-                0
-            ],
+            "position": [1600, 0],
             "inputs": {
                 "inputMesh": "{Meshing_1.outputMesh}"
             }
         },
-        "FeatureMatching_1": {
-            "nodeType": "FeatureMatching",
-            "position": [
-                600,
-                0
-            ],
-            "inputs": {
-                "input": "{FeatureExtraction_1.input}",
-                "featuresFolders": "{FeatureExtraction_1.output}",
-                "imagePairsList": "{}",
-                "describerTypes": "{FeatureExtraction_1.describerTypes}"
-            }
-        },
         "Texturing_1": {
             "nodeType": "Texturing",
-            "position": [
-                2178,
-                24
-            ],
+            "position": [1800, 0],
             "inputs": {
                 "input": "{Meshing_1.output}",
                 "imagesFolder": "{DepthMap_1.imagesFolder}",
@@ -140,10 +105,7 @@
         },
         "Publish_1": {
             "nodeType": "Publish",
-            "position": [
-                2272,
-                290
-            ],
+            "position": [2000, 0],
             "inputs": {
                 "inputFiles": [
                     "{Texturing_1.output}",

--- a/src/openlifu/nav/meshroom_pipelines/draft_pipeline.mg
+++ b/src/openlifu/nav/meshroom_pipelines/draft_pipeline.mg
@@ -1,28 +1,78 @@
 {
     "header": {
+        "releaseVersion": "2025.1.0",
+        "fileVersion": "2.0",
         "nodesVersions": {
+            "CameraInit": "12.0",
             "FeatureExtraction": "1.3",
-            "StructureFromMotion": "3.3",
-            "ImageMatching": "2.0",
-            "PrepareDenseScene": "3.1",
-            "MeshFiltering": "3.0",
             "FeatureMatching": "2.0",
-            "Texturing": "6.0",
-            "CameraInit": "9.0",
+            "MeshFiltering": "3.0",
             "Meshing": "7.0",
-            "Publish": "1.3"
-        },
-        "releaseVersion": "2023.3.0",
-        "fileVersion": "1.1",
-        "template": true
+            "PrepareDenseScene": "3.1",
+            "Publish": "1.3",
+            "StructureFromMotion": "3.3",
+            "Texturing": "6.0"
+        }
     },
     "graph": {
+        "CameraInit_1": {
+            "nodeType": "CameraInit",
+            "position": [0, 0],
+            "inputs": {}
+        },
+        "FeatureExtraction_1": {
+            "nodeType": "FeatureExtraction",
+            "position": [200, 0],
+            "inputs": {
+                "input": "{CameraInit_1.output}",
+                "describerTypes": ["dspsift"],
+                "forceCpuExtraction": false
+            }
+        },
+        "FeatureMatching_1": {
+            "nodeType": "FeatureMatching",
+            "position": [400, 0],
+            "inputs": {
+                "input": "{FeatureExtraction_1.input}",
+                "featuresFolders": ["{FeatureExtraction_1.output}"],
+                "imagePairsList": "",
+                "describerTypes": "{FeatureExtraction_1.describerTypes}"
+            }
+        },
+        "StructureFromMotion_1": {
+            "nodeType": "StructureFromMotion",
+            "position": [600, 0],
+            "inputs": {
+                "input": "{FeatureMatching_1.input}",
+                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
+                "matchesFolders": ["{FeatureMatching_1.output}"],
+                "describerTypes": "{FeatureMatching_1.describerTypes}"
+            }
+        },
+        "PrepareDenseScene_1": {
+            "nodeType": "PrepareDenseScene",
+            "position": [800, 0],
+            "inputs": {
+                "input": "{StructureFromMotion_1.output}"
+            }
+        },
+        "Meshing_1": {
+            "nodeType": "Meshing",
+            "position": [1000, 0],
+            "inputs": {
+                "input": "{PrepareDenseScene_1.input}"
+            }
+        },
+        "MeshFiltering_1": {
+            "nodeType": "MeshFiltering",
+            "position": [1200, 0],
+            "inputs": {
+                "inputMesh": "{Meshing_1.outputMesh}"
+            }
+        },
         "Texturing_1": {
             "nodeType": "Texturing",
-            "position": [
-                1600,
-                0
-            ],
+            "position": [1400, 0],
             "inputs": {
                 "input": "{Meshing_1.output}",
                 "imagesFolder": "{PrepareDenseScene_1.output}",
@@ -33,89 +83,9 @@
                 }
             }
         },
-        "Meshing_1": {
-            "nodeType": "Meshing",
-            "position": [
-                1200,
-                0
-            ],
-            "inputs": {
-                "input": "{PrepareDenseScene_1.input}"
-            }
-        },
-        "FeatureExtraction_1": {
-            "nodeType": "FeatureExtraction",
-            "position": [
-                200,
-                0
-            ],
-            "inputs": {
-                "input": "{CameraInit_1.output}",
-                "forceCpuExtraction": false
-            }
-        },
-        "StructureFromMotion_1": {
-            "nodeType": "StructureFromMotion",
-            "position": [
-                800,
-                0
-            ],
-            "inputs": {
-                "input": "{FeatureMatching_1.input}",
-                "featuresFolders": "{FeatureMatching_1.featuresFolders}",
-                "matchesFolders": [
-                    "{FeatureMatching_1.output}"
-                ],
-                "describerTypes": "{FeatureMatching_1.describerTypes}"
-            }
-        },
-        "CameraInit_1": {
-            "nodeType": "CameraInit",
-            "position": [
-                0,
-                0
-            ],
-            "inputs": {}
-        },
-        "MeshFiltering_1": {
-            "nodeType": "MeshFiltering",
-            "position": [
-                1400,
-                0
-            ],
-            "inputs": {
-                "inputMesh": "{Meshing_1.outputMesh}"
-            }
-        },
-        "FeatureMatching_1": {
-            "nodeType": "FeatureMatching",
-            "position": [
-                600,
-                0
-            ],
-            "inputs": {
-                "input": "{FeatureExtraction_1.input}",
-                "featuresFolders": "{FeatureExtraction_1.output}",
-                "imagePairsList": "{}",
-                "describerTypes": "{FeatureExtraction_1.describerTypes}"
-            }
-        },
-        "PrepareDenseScene_1": {
-            "nodeType": "PrepareDenseScene",
-            "position": [
-                1000,
-                0
-            ],
-            "inputs": {
-                "input": "{StructureFromMotion_1.output}"
-            }
-        },
         "Publish_1": {
             "nodeType": "Publish",
-            "position": [
-                2272,
-                290
-            ],
+            "position": [1600, 0],
             "inputs": {
                 "inputFiles": [
                     "{Texturing_1.output}",

--- a/src/openlifu/nav/photoscan.py
+++ b/src/openlifu/nav/photoscan.py
@@ -422,15 +422,17 @@ def run_reconstruction(
     durations["ImageResizing"] = time.perf_counter() - start_time
 
     output_dir = temp_dir / "output"
-    cache_dir = temp_dir / "cache"
+    # Meshroom 2025 ignores --cache and writes to MeshroomCache inside the working directory
+    cache_dir = temp_dir / "MeshroomCache"
     pair_file_path = cache_dir / "imageMatches.txt"
 
+    project_file = temp_dir / "project.mg"
     command = [
         "meshroom_batch",
         "--pipeline", pipeline.as_posix(),
         "--output", output_dir.as_posix(),
         "--input", images_dir.as_posix(),
-        "--cache", cache_dir.as_posix(),
+        "--save", project_file.as_posix(),
         "--paramOverrides", f"FeatureMatching_1.imagePairsList={pair_file_path.as_posix()}",
     ]
 
@@ -445,7 +447,7 @@ def run_reconstruction(
 
     #run CameraInit node to set view ids
     progress_callback(8, "Initializing camera IDs")
-    command_camera_init = [*command.copy(), "--toNode", "CameraInit"]
+    command_camera_init = [*command.copy(), "--toNode", "CameraInit_1"]
     subprocess_stream_output(command_camera_init, logger_meshroom.info, logger_meshroom.warning)
 
     camera_init_path = next(cache_dir.glob("CameraInit/*/cameraInit.sfm"))


### PR DESCRIPTION
Closes #427 

Updates OpenLIFU's photoscan reconstruction pipeline to be compatible with Meshroom 2025.1.0, replacing the previously supported Meshroom 2023.3.0. 

### Main changes:
**Pipeline files (src/openlifu/nav/meshroom_pipelines/*.mg)**
- Bumped releaseVersion from 2023.3.0 to 2025.1.0 and fileVersion from 1.1 to 2.0 across all five pipeline templates
- Updated node versions to match Meshroom 2025 (e.g. CameraInit 9.0 → 12.0)
- Added explicit `describerTypes: ["dspsift"]` to `FeatureExtraction` nodes, reflecting a new required field in Meshroom 2025
- Reformatted input references to match the Meshroom 2025 .mg file schema (fileVersion 2.0)

**photoscan.py**

-  Replaced `--cache` CLI flag with --save <project_file>  since Meshroom 2025 seems to ignore the `--cache` spec and instead writes cache output to MeshroomCache/ inside the working directory
- Updated `cache_dir` path accordingly (temp_dir / "MeshroomCache")
- Fixed node name reference from `"CameraInit"` to `"CameraInit_1"` to match the node naming convention used in the updated pipeline files
