### PR TITLE
Add sample data instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,37 +121,22 @@ To ensure Meshroom uses your NVIDIA GPU:
 5. Under **Select the preferred graphics processor for this program**, choose **High-performance NVIDIA processor**.
 6. Click **Apply**.
 
-Version control of database using DVC (Data Version Control)
--------------------------------------------------------------
+Getting Sample Data
+-------------------
 
-Data Version Control (DVC) is a data management tool that is meant to be run alongside Git.
-In this project, DVC is used to link changes in the code to specific versions of a sample database containing example project files.
-DVC can be used when this project is installed in Dev mode. You can read more about DVC and how to use it `here <https://dvc.org/doc/start>`_.
-**Note:** Remote access to the sample database stored on google drive is currently restricted. Access requires a :code:`gdrive_client_secret`
-for user access authentication to be shared by developers.
+A sample database for testing and examples is maintained in the
+`openlifu-sample-database <https://github.com/OpenwaterHealth/openlifu-sample-database>`_
+repository. Its files are tracked with Git LFS, so first `install Git LFS
+<https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage>`_.
 
-DVC usage
-~~~~~~~~~
+Then check out the tagged version of the sample database that is compatible
+with this version of ``openlifu``:
 
-To download the sample database:
+.. code:: bash
 
-.. code:: sh
-
-   git pull
-   dvc remote modify --local shared_gdrive gdrive_client_secret <client_secret_here> # Contact developers for grive_client_secret
-   dvc pull # Requires access to remote storage
-
-This will download a directory 'db_dvc' in the repo directory that
-contains the corresponding version of example database files.
-
-To commit updates to the sample database:
-
-.. code:: sh
-
-   dvc add db_dvc
-   git commit -m "Describe updates to database"
-   git push
-   dvc push #Requires access to remote storage
+   git clone --depth 1 --branch openlifu-v0.20.0 https://github.com/OpenwaterHealth/openlifu-sample-database.git
+   cd openlifu-sample-database
+   git lfs pull
 
 Disclaimer
 ----------

--- a/examples/tools/standardize_database.py
+++ b/examples/tools/standardize_database.py
@@ -1,11 +1,11 @@
-"""This is a utility script for developers to read in and write back out the dvc database.
-It is useful for standardizing the format of the example dvc data, and also for checking that the database
+"""This is a utility script for developers to read in and write back out an openlifu database.
+It is useful for standardizing the format of the example data, and also for checking that the database
 mostly still works.
 
 To use this script, install openlifu to a python environment and then run the script providing the database folder as an argument:
 
 ```
-python standardize_database.py db_dvc/
+python standardize_database.py /path/to/openlifu-sample-database
 ```
 
 A couple of known issues to watch out for:
@@ -15,7 +15,6 @@ A couple of known issues to watch out for:
 """
 from __future__ import annotations
 
-import logging
 import pathlib
 import shutil
 import sys
@@ -23,7 +22,6 @@ import tempfile
 
 from openlifu.db import Database
 from openlifu.db.database import OnConflictOpts
-from openlifu.xdc import Transducer
 
 if len(sys.argv) != 2:
     raise RuntimeError("Provide exactly one argument: the path to the database folder.")
@@ -38,9 +36,6 @@ for protocol_id in db.get_protocol_ids():
 db.write_transducer_ids(db.get_transducer_ids())
 for transducer_id in db.get_transducer_ids():
     transducer = db.load_transducer(transducer_id, convert_array=False)
-    if not isinstance(transducer, Transducer):
-        logging.warning(f"Skipping {transducer_id} because TransducerArray writing is not supported.")
-        continue
     assert transducer_id == transducer.id
     db.write_transducer(transducer, on_conflict=OnConflictOpts.OVERWRITE)
 


### PR DESCRIPTION
Replacing DVC by the [openlifu-sample-database](https://github.com/OpenwaterHealth/openlifu-sample-database) as a source of sample data to direct new users to.

I will push tags to openlifu-sample-database that we can reference in the git clone command in the README here. Right now there is just one tag [openlifu-v0.20.0](https://github.com/OpenwaterHealth/openlifu-sample-database/tree/openlifu-v0.20.0) indicating which version of the sample data should be used with openlifu v0.20.0.

Once this is merged, I will updated our release notes for our latest releases to point to this new section in the readme, rather than pointing to dvc data.

For review: Just look at the updated readme and see that the formatting and instructions are sensible.