### PR TITLE
Copy pipeline graph to temp dir to avoid whitespaces in path

### DIFF
--- a/src/openlifu/nav/photoscan.py
+++ b/src/openlifu/nav/photoscan.py
@@ -422,10 +422,14 @@ def run_reconstruction(
     cache_dir = temp_dir / "MeshroomCache"
     pair_file_path = cache_dir / "imageMatches.txt"
 
+    # Copy pipeline to temp directory without spaces
+    pipeline_copied = temp_dir / f"{pipeline_name}.mg"
+    shutil.copy(pipeline, pipeline_copied)
+
     project_file = temp_dir / "project.mg"
     command = [
         "meshroom_batch",
-        "--pipeline", pipeline.as_posix(),
+        "--pipeline", pipeline_copied.as_posix(),
         "--output", output_dir.as_posix(),
         "--input", images_dir.as_posix(),
         "--save", project_file.as_posix(),


### PR DESCRIPTION
Meshroom 2025.1.0 has a bug (alicevision/Meshroom#2808) where paths containing spaces are not properly quoted when `meshroom_compute` is launched internally. This causes `meshroom_batch` to fail with unrecognized arguments when the pipeline .mg file lives in a directory with spaces (e.g., OpenLIFU installation dir).

Work around this by copying the pipeline file to the temp directory before passing it to meshroom_batch.

However, this is not a full guarantee if the temp directory itself contains spaces (i.e. if the username has spaces) - although this is usually not the case. 