### PR TITLE
Adjust time averaged intensity calculation (#479)

### DIFF
--- a/src/openlifu/plan/solution.py
+++ b/src/openlifu/plan/solution.py
@@ -489,15 +489,14 @@ class Solution:
             intensity_scaled = rescale_data_arr(intensity, units)
         else:
             intensity_scaled = rescale_data_arr(self.simulation_result['intensity'], units)
-        pulsetrain_dutycycle = self.get_pulsetrain_dutycycle()
-        treatment_dutycycle = self.get_sequence_dutycycle()
+        sequence_dutycycle = self.get_sequence_dutycycle()
         pulse_seq = (np.arange(self.sequence.pulse_count) - 1) % self.num_foci() + 1
         counts = np.zeros((1, 1, 1, self.num_foci()))
         for i in range(self.num_foci()):
             counts[0, 0, 0, i] = np.sum(pulse_seq == (i+1))
         intensity = intensity_scaled.copy(deep=True)
         isppa_avg = np.sum(np.expand_dims(intensity.data, axis=-1) * counts, axis=-1) / np.sum(counts)
-        intensity.data = isppa_avg * pulsetrain_dutycycle * treatment_dutycycle
+        intensity.data = isppa_avg * sequence_dutycycle
 
         return intensity
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -143,6 +143,29 @@ def test_num_foci(example_solution:Solution):
     assert example_solution.delays.shape[0] == num_foci
     assert example_solution.apodizations.shape[0] == num_foci
 
+
+def test_get_ita():
+    """Verify that ITA applies the overall sequence duty cycle exactly once."""
+    solution = Solution(
+        pulse=Pulse(duration=0.08),
+        sequence=Sequence(
+            pulse_interval=0.1,
+            pulse_count=10,
+            pulse_train_interval=2.0,
+        ),
+        foci=[Point()],
+    )
+    intensity = xa.DataArray(
+        np.array([[[[5.0]]]]),
+        dims=("focal_point_index", "x", "y", "z"),
+        attrs={"units": "W/cm^2"},
+    )
+
+    assert solution.get_pulsetrain_dutycycle() == pytest.approx(0.8) # 0.08 / 0.1 = 0.8
+    assert solution.get_sequence_dutycycle() == pytest.approx(0.4) # 0.8 * ( 10*0.1 / 2.0 ) = 0.4
+    assert solution.get_ita(intensity).item() == pytest.approx(2000.0) # 5.0 * 0.4 = 2 W/cm^2 = 2000 mW/cm^2
+
+
 @pytest.mark.parametrize("compact_representation", [True, False])
 def test_json_serialize_deserialize_solution_analysis(compact_representation: bool):
     """Verify that turning a SolutionAnalysis into json and then re-constructing it gets back to the original"""


### PR DESCRIPTION
Closes #479

This has apparently been an issue since #335, back in 0.7.0. I adjusted the calculation of treatment duty cycle to include the pulse train duty cycle derating for display, but failed to notice that ITA values were being double-derated by the pulse train duty cycle. So while PNP and ISPPA have been being calculated correctly, ISPTA has shown up as much less than the duty cycle would predict.