### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - "release/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,7 +32,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          pattern='(#[0-9]+|github\.com/[^/]+/[^/]+/issues/[0-9]+|^Bump |^Merge |^Revert |^fixup! |^squash! |^amend! )'
+          pattern='(#[0-9]+|github\.com/[^/]+/[^/]+/issues/[0-9]+|^Bump |^Merge |^Release |^Revert |^fixup! |^squash! |^amend! )'
           failed=0
           for sha in $(git log --format="%H" "$BASE_SHA".."$HEAD_SHA"); do
             msg=$(git log -1 --format="%B" "$sha")
@@ -45,7 +46,7 @@ jobs:
           if [ "$failed" -eq 1 ]; then
             echo ""
             echo "Every commit must reference a GitHub issue (e.g., #123 or full issue URL)."
-            echo "Exceptions: Bump, Merge, Revert, fixup!, squash!, amend! commits."
+            echo "Exceptions: Bump, Merge, Release, Revert, fixup!, squash!, amend! commits."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,8 @@ nox -s docs
 CI runs on push to main and on PRs (`.github/workflows/ci.yml`):
 
 1. **Commit message check** (PRs only): every commit must reference a GitHub
-   issue (`#123` or full URL). Exceptions: Bump, Merge, Revert, fixup!, squash!,
-   amend! commits.
+   issue (`#123` or full URL). Exceptions: Bump, Merge, Release, Revert, fixup!,
+   squash!, amend! commits.
 2. **Pre-commit + PyLint**: linting on ubuntu.
 3. **Tests**: matrix of Python {3.10, 3.12} x {ubuntu, windows, macos} with
    coverage uploaded to Codecov.


### PR DESCRIPTION
Extend CI to run automatically on release branches. We should have done this after updating the release process in #474 

(I triggered the CI run manually on the 0.21 branch)