### PR TITLE
Remove radius and color from Point

### DIFF
--- a/examples/tutorials/01_Introduction_And_Object_Creation.py
+++ b/examples/tutorials/01_Introduction_And_Object_Creation.py
@@ -44,7 +44,7 @@ from openlifu.xdc import Transducer  # We'll briefly touch on this
 # %% [markdown]
 # ## 1. `Point`
 #
-# A `Point` object defines a location in 3D space. It can also have a radius, making it a sphere.
+# A `Point` object defines a location in 3D space.
 # Positions are typically specified in millimeters.
 
 # %%

--- a/examples/tutorials/03_Solution_Generation_and_Analysis.py
+++ b/examples/tutorials/03_Solution_Generation_and_Analysis.py
@@ -52,7 +52,7 @@ from openlifu.xdc import Transducer
 # This is a `Point` object representing the desired focal location.
 
 # %%
-target = Point(position=np.array([0, 0, 50]), units="mm", radius=0.5) # 50mm depth, small radius
+target = Point(position=np.array([0, 0, 50]), units="mm")  # 50 mm depth
 print(f"Target: {target}")
 
 # %% [markdown]

--- a/src/openlifu/bf/focal_patterns/wheel.py
+++ b/src/openlifu/bf/focal_patterns/wheel.py
@@ -56,11 +56,12 @@ class Wheel(FocalPattern):
             theta = 2*np.pi*i/self.num_spokes
             local_position = self.spoke_radius * np.array([np.cos(theta), np.sin(theta), 0.0])
             position = np.dot(m, np.append(local_position, 1.0))[:3]
-            spoke = Point(id=f"{target.id}_{np.rad2deg(theta):.0f}deg",
-                              name=f"{target.name} ({np.rad2deg(theta):.0f}°)",
-                              position=position,
-                              units=self.distance_units,
-                              radius=target.radius)
+            spoke = Point(
+    id=f"{target.id}_{np.rad2deg(theta):.0f}deg",
+    name=f"{target.name} ({np.rad2deg(theta):.0f}°)",
+    position=position,
+    units=self.distance_units,
+)
             targets.append(spoke)
         return targets
 

--- a/src/openlifu/geo/point.py
+++ b/src/openlifu/geo/point.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import json
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Dict, Tuple
+from typing import Annotated, Dict, Tuple
 
 import numpy as np
 
@@ -21,12 +21,6 @@ class Point:
 
     name: Annotated[str, OpenLIFUFieldData("Point name", "Name of the point")] = "Point"
     """Name of the point"""
-
-    color: Annotated[Any, OpenLIFUFieldData("Color (RGB)", "RGB color of the point")] = (1.0, 0.0, 0.0)
-    """RGB color of the point"""
-
-    radius: Annotated[float, OpenLIFUFieldData("Radius", "Radius for rendering the point in the provided units")] = 1.0  # mm
-    """Radius for rendering the point in the provided units"""
 
     dims: Annotated[Tuple[str, str, str], OpenLIFUFieldData("Dimensions", "Names of the axes of the coordinate system being used")] = ("x", "y", "z")
     """Names of the axes of the coordinate system being used"""
@@ -74,33 +68,51 @@ class Point:
             m = np.dot(origin, m)
         return m
 
-    def get_polydata(self, transform: np.ndarray = np.eye(4), units=None):
+    def get_polydata(
+        self,
+        transform: np.ndarray = np.eye(4),
+        units=None,
+        radius: float = 1.0,
+    ):
         import vtk
+
         units = self.units if units is None else units
-        colors = vtk.vtkNamedColors()
         sphereSource = vtk.vtkSphereSource()
         scl = getunitconversion(self.units, units)
         pos = np.dot(transform, np.append(self.position * scl, 1.0))[:3]
         sphereSource.SetCenter(*pos)
-        sphereSource.SetRadius(self.radius * scl)
+        sphereSource.SetRadius(radius * scl)
         sphereSource.SetPhiResolution(100)
         sphereSource.SetThetaResolution(100)
         return sphereSource
 
-    def get_actor(self, transform: np.ndarray = np.eye(4), units=None):
+    def get_actor(
+        self,
+        transform: np.ndarray = np.eye(4),
+        units=None,
+        color=(1.0, 0.0, 0.0),
+        radius: float = 1.0,
+    ):
         import vtk
-        polydata = self.get_polydata(transform=transform, units=units)
+
+        polydata = self.get_polydata(
+            transform=transform,
+            units=units,
+            radius=radius,
+        )
+
         mapper = vtk.vtkPolyDataMapper()
         mapper.SetInputConnection(polydata.GetOutputPort())
+
         actor = vtk.vtkActor()
         actor.SetMapper(mapper)
-        actor.GetProperty().SetColor(self.color)
+        actor.GetProperty().SetColor(color)
+
         return actor
 
     def rescale(self, units: str):
         scl = getunitconversion(self.units, units)
         self.position = self.position * scl
-        self.radius = self.radius * scl
         self.units = units
 
     def transform(
@@ -117,24 +129,22 @@ class Point:
 
     def to_dict(self):
         return {
-            "id": self.id,
-            "name": self.name,
-            "color": self.color,
-            "radius": self.radius,
-            "position": self.position.tolist(),
-            "dims": self.dims,
-            "units": self.units,
-        }
+        "id": self.id,
+        "name": self.name,
+        "position": self.position.tolist(),
+        "dims": self.dims,
+        "units": self.units,
+    }
 
     @staticmethod
     def from_dict(point_data: Dict):
         """Create a Point object from a dictionary."""
-        if "color" in point_data:
-            if len(point_data["color"]) != 3:
-                raise ValueError(f"Color should have three components; got {point_data['color']}.")
-            point_data["color"] = tuple(float(point_data["color"][i]) for i in range(3))
-        if "radius" in point_data:
-            point_data["radius"] = float(point_data["radius"])
+        point_data = point_data.copy()
+
+        # Ignore legacy rendering properties.
+        point_data.pop("color", None)
+        point_data.pop("radius", None)
+
         if "position" in point_data:
             point_data["position"] = np.array(point_data["position"])
         if "dims" in point_data:

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -10,13 +10,11 @@ from openlifu.geo.point import Point
 @pytest.fixture()
 def example_point() -> Point:
     return Point(
-        id = "example_point",
+        id="example_point",
         name="Example point",
-        color=(0.,0.7, 0.2),
-        radius=1.5,
-        position=np.array([-10.,0,25]),
-        dims = ("R", "A", "S"),
-        units = "m",
+        position=np.array([-10., 0, 25]),
+        dims=("R", "A", "S"),
+        units="m",
     )
 
 @pytest.mark.parametrize("compact_representation", [True, False])


### PR DESCRIPTION
Closes #102

This PR removes the `radius` and `color` properties from `Point`.

### Changes

- Remove `radius` and `color` from the `Point` dataclass and serialized representation.
- Preserve compatibility with existing serialized data by ignoring legacy `radius` and `color` fields during deserialization.
- Allow rendering radius and color to be provided directly to the rendering methods instead of storing them on `Point`.
- Update the wheel focal pattern to no longer depend on `target.radius`.
- Update affected tutorials and `Point` tests.

### Testing

- `pytest` — 324 passed, 2 skipped
- `pre-commit run --all-files` — all checks passed

The two skipped tests are the existing macOS/architecture-specific skips.
