### PR TITLE
Fix sphinx docs display of support schedule (#338)

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,4 @@
+```{include} ../SUPPORT.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/includeme.md
+++ b/docs/includeme.md
@@ -2,4 +2,6 @@
 
 ```{include} ../README.md
 :start-after: <!-- SPHINX-START -->
+:relative-docs: docs/
+:relative-images:
 ```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to openlifu's documentation!
    :caption: Contents:
 
    includeme
+   SUPPORT
    architecture
    api
 


### PR DESCRIPTION
After #504, the relative links were broken at https://openlifu.readthedocs.io/en/latest/includeme.html#supported-versions so this should fix them